### PR TITLE
Set up skills plugin foundation with directory structure and scaffolding

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "claude-skills",
+  "description": "Personal collection of reusable Claude Code skills and plugins.",
+  "version": "0.1.0",
+  "skills": "./skills/"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,52 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A personal collection of custom Claude Code skills and plugins.
+A Claude Code skills plugin repository. Install as a plugin to gain access to reusable skills across multiple machines and projects. Skills are updated centrally and propagated via `git pull`.
+
+## Directory Structure
+
+```
+.claude-plugin/
+  plugin.json                     # Plugin manifest (required)
+skills/
+  <skill-name>/
+    SKILL.md                      # Required — skill definition with YAML frontmatter
+    template.md                   # Optional — output templates
+    reference.md                  # Optional — detailed reference material
+    examples/                     # Optional — example inputs/outputs
+    scripts/                      # Optional — helper scripts
+```
+
+Multi-stage skills use a flat layout with a shared prefix (e.g., `feature-creator/`, `feature-creator-planning/`, `feature-creator-reviewing/`). The parent skill acts as an orchestrator and may contain supporting `.md` files for its sub-skills.
+
+## Skill Authoring Conventions
+
+### Naming
+- Directory names: lowercase with hyphens (e.g., `daily-code-scrub`)
+- Prefer gerund form for action-oriented skills (e.g., `code-reviewing`)
+- Use descriptive noun-phrases for task-oriented skills (e.g., `daily-code-scrub`)
+- Multi-stage sub-skills share a prefix: `<parent>-<stage>` (e.g., `feature-creator-planning`)
+
+### SKILL.md Format
+Every skill requires a `SKILL.md` with YAML frontmatter:
+
+```yaml
+---
+name: skill-name                  # Required — matches directory name
+description: What the skill does  # Required — one-line summary
+argument-hint: "<args>"           # Optional — shown during autocomplete
+allowed-tools: Tool1, Tool2       # Optional — tools the skill can use
+context: fork                     # Optional — run in isolated subagent
+agent: Plan                       # Optional — subagent type (Explore, Plan, general-purpose)
+---
+```
+
+### Guidelines
+- Keep SKILL.md under 500 lines; move detail into supporting files
+- Skills are discovered **one level deep** under `skills/` — do not nest skill directories
+- Supporting files (`.md`, scripts) inside a skill directory are loaded on-demand, not as separate skills
+- Test changes by editing SKILL.md and re-invoking — no restart needed
 
 ## Build & Test Commands
 
-_No build or test commands exist yet. Update this section as tooling is added._
+No build or test commands. This is a pure-markdown skills repository.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
 # claude-skills
 
+A personal collection of reusable [Claude Code](https://claude.ai/code) skills, structured as a plugin repository. Install once, use everywhere, update via `git pull`.
+
+## Installation
+
+```bash
+# Clone the repo (one-time setup)
+git clone https://github.com/schmimran/claude-skills.git ~/claude-skills
+
+# In any project, register the plugin
+claude plugins add ~/claude-skills
+```
+
+All skills in the `skills/` directory are automatically discovered.
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| `daily-code-scrub` | Daily maintenance pass — linting, dependency checks, dead code removal |
+| `feature-creator` | Multi-agent workflow: GitHub issue to plan to review to implementation |
+
+### feature-creator Sub-skills
+
+| Stage | Skill | Description |
+|-------|-------|-------------|
+| 1 | `feature-creator-planning` | Analyze GitHub issue and create implementation plan |
+| 2 | `feature-creator-reviewing` | Review plan against project architecture |
+| 3 | `feature-creator-implementing` | Execute plan, write code, open PR |
+
+## Usage
+
+```
+/daily-code-scrub
+/feature-creator 42
+```
+
+## Creating New Skills
+
+1. Create a directory under `skills/` with a hyphenated lowercase name
+2. Add a `SKILL.md` with YAML frontmatter (`name`, `description` at minimum)
+3. Keep `SKILL.md` under 500 lines — use supporting files for additional detail
+4. See [CLAUDE.md](CLAUDE.md) for full authoring conventions
+
+## How Updates Work
+
+This repo is installed as a plugin via a local path. When you `git pull` in the cloned repo, every project using the plugin picks up the changes on the next invocation. No reinstallation needed.
+
+## License
+
+[MIT](LICENSE)

--- a/skills/daily-code-scrub/SKILL.md
+++ b/skills/daily-code-scrub/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: daily-code-scrub
+description: Run a daily maintenance pass over a code project — lint fixes, dependency checks, dead code removal, and hygiene tasks.
+argument-hint: "[project-path]"
+---
+
+# Daily Code Scrub
+
+<!-- TODO: Define the full maintenance checklist and implementation -->

--- a/skills/feature-creator-implementing/SKILL.md
+++ b/skills/feature-creator-implementing/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: feature-creator-implementing
+description: "Agent 3: Execute an approved implementation plan — write code, create tests, and prepare a pull request."
+argument-hint: "<plan-file-path>"
+---
+
+# Implementing
+
+<!-- TODO: Implement plan execution, code generation, testing, and PR creation -->

--- a/skills/feature-creator-planning/SKILL.md
+++ b/skills/feature-creator-planning/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: feature-creator-planning
+description: "Agent 1: Retrieve a GitHub issue, analyze requirements, explore the codebase, and produce an implementation plan."
+argument-hint: "<issue-number-or-url>"
+---
+
+# Planning
+
+<!-- TODO: Implement issue retrieval, codebase analysis, and plan generation -->

--- a/skills/feature-creator-reviewing/SKILL.md
+++ b/skills/feature-creator-reviewing/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: feature-creator-reviewing
+description: "Agent 2: Review an implementation plan against project structure, deployment configuration, and coding standards."
+argument-hint: "<plan-file-path>"
+---
+
+# Reviewing
+
+<!-- TODO: Implement plan validation, risk assessment, and approval workflow -->

--- a/skills/feature-creator/SKILL.md
+++ b/skills/feature-creator/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: feature-creator
+description: Multi-agent workflow that takes GitHub issues from analysis through implementation — plan, review, and execute.
+argument-hint: "<issue-number-or-url>"
+---
+
+# Feature Creator
+
+Orchestrates a 3-stage pipeline:
+
+1. **Planning** — `/feature-creator-planning`
+2. **Reviewing** — `/feature-creator-reviewing`
+3. **Implementing** — `/feature-creator-implementing`
+
+<!-- TODO: Implement orchestration logic to chain sub-skills -->

--- a/skills/feature-creator/implementing.md
+++ b/skills/feature-creator/implementing.md
@@ -1,0 +1,3 @@
+# Implementing Stage
+
+<!-- TODO: Detailed Agent 3 instructions -->

--- a/skills/feature-creator/planning.md
+++ b/skills/feature-creator/planning.md
@@ -1,0 +1,3 @@
+# Planning Stage
+
+<!-- TODO: Detailed Agent 1 instructions -->

--- a/skills/feature-creator/reviewing.md
+++ b/skills/feature-creator/reviewing.md
@@ -1,0 +1,3 @@
+# Reviewing Stage
+
+<!-- TODO: Detailed Agent 2 instructions -->


### PR DESCRIPTION
Establish the repo as a Claude Code plugin with:
- Plugin manifest (.claude-plugin/plugin.json)
- Skeleton skills: daily-code-scrub, feature-creator (orchestrator + 3 sub-skills)
- CLAUDE.md with skill authoring conventions and directory structure guide
- README.md with installation instructions and skill catalog

https://claude.ai/code/session_01YKASsCd5ozwEifhAKC8EtH