### PR TITLE
Add author field to marketplace plugin entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,10 @@
       "name": "feature-creator",
       "source": "./plugins/feature-creator",
       "description": "Feature development pipeline — GitHub issues to implementation plans to PRs.",
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "author": {
+        "name": "schmimran"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the `author` field to the plugin entry in `marketplace.json`. Without it, the marketplace UI shows no install button and attribution falls back to the marketplace name instead of the plugin author.

## Test plan

- [ ] Run `/plugin marketplace update` and verify the install button appears
- [ ] Verify attribution shows "by schmimran" instead of "by claude-skills"