### PR TITLE
docs: overhaul documentation for clarity, consistency, and completeness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,61 +33,9 @@ plugins/
 
 Each plugin lives under `plugins/<name>/` and is independently installable. Plugins use the **commands + agents** pattern: commands are user-invocable orchestrators, agents are specialized workers launched by commands.
 
-## Feature-Creator Pipeline
+## Plugin System
 
-### Label Lifecycle
-
-```
-[human]               [planner]          [implementer]        [implementer]
-ready for claude  -->  planned  -------->  in progress  ------->  complete
-                          |                     |
-                   [reviewer: risky]     [impl failed]
-                          |                     |
-                          +-->  human review  <-+
-```
-
-| Label | Set by | Meaning |
-|-------|--------|---------|
-| `feature - ready for claude` | Human | Issue is scoped and ready for automated planning |
-| `feature - planned` | feature-planner agent | Plan posted as issue comment |
-| `feature - human review` | feature-reviewer or feature-implementer agent | Flagged as high-risk or implementation failed |
-| `feature - in progress` | feature-implementer agent | Branch created, coding underway |
-| `feature - complete` | feature-implementer agent | PR created and code-reviewed |
-
-### Plan Comments
-
-Plans are posted as **comments** on the issue (the issue body is never modified). Every plan comment is prefixed with `<!-- claude-feature-planner-v1 -->` so downstream agents can locate it programmatically.
-
-### Error Handling Pattern
-
-When any agent encounters a failure for a specific issue:
-1. Post a comment on the issue explaining the error
-2. Change the label to `feature - human review`
-3. Continue processing remaining issues
-
-### Stuck State Recovery
-
-If an agent crashes or is interrupted while a feature is labeled `feature - in progress`, that issue will be skipped on the next run (since agents query for `feature - planned`, not `feature - in progress`). To recover, manually relabel the stuck issue:
-```
-gh issue edit <NUMBER> --remove-label "feature - in progress" --add-label "feature - planned"
-```
-Then delete the orphaned branch if one was created.
-
-### Batch Size
-
-The orchestrator command warns when more than 5 issues are labeled `feature - ready for claude`, but this guard is **advisory only**. The agents each fetch up to 20 issues independently. If strict batch limiting is needed, manually control which issues carry the trigger label.
-
-### Concurrency
-
-This pipeline is single-operator tooling. Do not run multiple instances against the same repository simultaneously.
-
-### Shell Safety
-
-All `gh` commands that pass untrusted content (issue titles, plan text, error messages) must use `--body-file` instead of `--body` to prevent shell injection. Never interpolate issue content directly into shell command strings.
-
-## Plugin Onboarding
-
-### Plugin structure requirements
+### Structure requirements
 
 - Each plugin is a self-contained directory under `plugins/<name>/` with its own `.claude-plugin/plugin.json` and `README.md`
 - Plugins use the **commands + agents** pattern: `commands/` for user-facing orchestrators, `agents/` for specialized workers, `references/` for supporting docs
@@ -121,8 +69,10 @@ Commands live in `commands/*.md` and are user-invocable orchestrators:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `description` | Yes | One-line summary shown in the `/` menu |
+| `name` | Recommended | Slash command name (e.g., `feature-creator` → `/feature-creator`). Inferred from filename if omitted. |
+| `description` | Yes | One-line summary shown in the `/` menu. Keep under 200 characters. |
 | `argument-hint` | No | Shown during autocomplete (e.g., `"[repo-owner/repo-name]"`) |
+| `disable-model-invocation` | No | Set `true` for commands with destructive side effects — prevents accidental auto-invocation |
 
 ### Dynamic Variables
 
@@ -138,10 +88,11 @@ Agents live in `agents/*.md` and are specialized workers launched by commands:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Agent identifier, lowercase with hyphens |
-| `description` | Yes | One-line summary of the agent's expertise |
+| `description` | Yes | One-line summary of the agent's expertise. Keep under 200 characters. |
 | `tools` | Yes | Comma-separated list of tools the agent can use |
 | `model` | No | Model to run the agent on: `sonnet`, `opus`, `haiku` |
 | `color` | No | UI color indicator: `red`, `yellow`, `green`, `blue` |
+| `disable-model-invocation` | No | Set `true` for agents that should only be launched by their orchestrator command |
 
 ### Tool Access
 
@@ -155,13 +106,15 @@ Agents declare tool access with the `tools:` field. Common tool sets:
 - Use `model: sonnet` for analysis/planning work, `model: opus` for code generation
 - Commands launch agents via the `Agent` tool; agents are not independently invocable
 - Move reference material to `references/` rather than embedding in agent files
+- Use `--body-file` for all `gh` commands that pass issue titles, plan text, or error messages — never interpolate untrusted content into shell strings
 
 ## Conventions
 
 - **Naming**: Directory names are lowercase with hyphens (e.g., `feature-creator`)
-- **Issue interaction**: Plans are posted as comments, never by modifying the issue body.
-- **Branching**: One branch per feature (`feature/<number>-<slug>`), plus a release branch after all features.
-- **Max batch size**: The orchestrator warns when more than 5 features are queued, but the guard is advisory only.
+- **Issue interaction**: Plans are posted as comments, never by modifying the issue body
+- **Branching**: One branch per feature (`feature/<number>-<slug>`), plus a release branch (`release/<YYYY-MM-DD>`) after all features
+- **Commits**: Conventional commit format, referencing the issue number (e.g., `feat: add widget (#42)`)
+- **Comment markers**: Plan comments are prefixed with `<!-- claude-feature-planner-v1 -->` and combined reviewer plans with `<!-- claude-feature-reviewer-v1 -->`. Downstream agents use these markers to locate content programmatically. Always include the correct marker or extraction will fail.
 
 ## Local Development
 
@@ -181,21 +134,21 @@ claude --plugin-dir /path/to/claude-skills/plugins/feature-creator
 ## Prerequisites
 
 - **`gh` CLI**: Must be installed and authenticated (`gh auth status`)
-- **Labels**: The target repository must have these labels created (see the feature-creator plugin README for setup commands):
-  - `feature - ready for claude`
-  - `feature - planned`
-  - `feature - human review`
-  - `feature - in progress`
-  - `feature - complete`
+- **Labels**: The target repository must have the five pipeline labels created. See the feature-creator plugin README for the setup commands.
 
 ## Build & Test Commands
 
 No build or test commands. This is a pure-markdown plugin repository.
 
-
-## Behavioral rules for AI contributors
+## Behavioral Rules for AI Contributors
 
 These apply to every Claude Code session in this repo.
 
-1. **Documentation targets.**  When updating docs per the global documentation rule, this includes: CLAUDE.md schema tables, the root README plugin catalog, and each affected plugin's README.
-2. **No silent additions.**  Do not add new files, directories, or environment variables without stating what you are adding and why.
+1. **Documentation targets.** When updating docs per the global documentation rule, this includes: CLAUDE.md schema tables, the root README plugin catalog, and each affected plugin's README.
+2. **No silent additions.** Do not add new files, directories, or environment variables without stating what you are adding and why.
+3. **Agent isolation.** Agents must not reference files outside their plugin directory. Each plugin must be independently installable.
+4. **Shell safety.** Follow the `--body-file` rule in Agent Authoring Guidelines above — it applies to every plugin, not just feature-creator.
+5. **Version sync.** When modifying an existing plugin, update `version` in both `plugin.json` and `marketplace.json` simultaneously — they must always match.
+6. **New plugin completeness.** Do not create a new plugin directory without completing all 5 steps of the Adding a New Plugin checklist above.
+7. **Issue body immutability.** The issue body is never modified. All communication (plans, risk assessments, error reports) happens via comments.
+8. **Plan comment markers.** Always include the correct marker prefix (see Conventions above). Downstream agents will fail to locate comments if the marker is missing or wrong.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A Claude Code plugin marketplace. Install it once to get access to all plugins, with updates propagating automatically.
 
+## How It Works
+
+Each plugin in this marketplace is a **slash command** backed by a set of specialized AI agents. You install the marketplace once, and every plugin becomes immediately available in your Claude Code sessions — no per-plugin installation needed. When a plugin is updated, you get the new version automatically on next use.
+
+Plugins are self-contained: each lives in its own directory with its own agents, reference documents, and configuration. They don't share code with each other, so you can install the whole marketplace without worrying about interference between plugins.
+
 ## Installation
 
 ```bash
@@ -10,13 +16,17 @@ A Claude Code plugin marketplace. Install it once to get access to all plugins, 
 
 ## Available Plugins
 
-| Plugin | Description | Docs |
-|--------|-------------|------|
-| [feature-creator](plugins/feature-creator/) | Feature development pipeline — GitHub issues to implementation plans to PRs | [README](plugins/feature-creator/README.md) |
+| Plugin | Version | Description | Docs |
+|--------|---------|-------------|------|
+| [feature-creator](plugins/feature-creator/) | 0.3.0 | Feature development pipeline — GitHub issues to implementation plans to PRs | [README](plugins/feature-creator/README.md) |
 
-## Adding a New Plugin
+## What Each Plugin Does
 
-See [CLAUDE.md](CLAUDE.md) for the plugin onboarding checklist and conventions.
+**feature-creator** — Give it a GitHub repository and some labeled issues, and it handles the full development cycle automatically. It reads your codebase, writes a detailed implementation plan for each issue, checks whether each change is risky (and flags anything dangerous for human review), writes the code, runs your tests, opens pull requests, and — if you want — merges and cleans up. The only time it stops to ask is when it flags something as high-risk, or when you've asked it to pause before the final merge.
+
+## Contributing a Plugin
+
+See [CLAUDE.md](CLAUDE.md) for the plugin authoring conventions, structure requirements, and the step-by-step checklist for adding a new plugin.
 
 ## License
 

--- a/plugins/feature-creator/README.md
+++ b/plugins/feature-creator/README.md
@@ -78,7 +78,7 @@ The pipeline moves through four phases:
 
 **Phase 3 — Implementation**: The implementer agent works through approved features one at a time. For each: it creates a branch, writes the code, runs tests (with up to 3 retry attempts), follows the merge checklist (`/simplify` + `/code-review`), and opens a PR.
 
-**Phase 4 — Merge and Cleanup**: Feature PRs are merged in implementation order. The release branch PR is created linking all features. If the session is in plan mode, the pipeline pauses here for your confirmation. Otherwise it merges automatically, then deletes all feature branches (local and remote), pulls main, and removes any worktree.
+**Phase 4 — Merge and Cleanup**: Feature PRs are merged in implementation order. The release branch PR is created linking all features. By default, the pipeline pauses here for your confirmation before merging the release branch. Pass `--auto-merge` to skip the pause. After merge, it deletes all feature branches (local and remote), pulls main, and removes any worktree.
 
 ### Label Lifecycle
 

--- a/plugins/feature-creator/README.md
+++ b/plugins/feature-creator/README.md
@@ -1,19 +1,57 @@
 # feature-creator
 
-Automates feature development from GitHub issues through implementation. It plans, reviews for risk, implements, and opens PRs.
+Automates feature development end-to-end. Point it at a GitHub repository, label your issues, and it will analyze your codebase, write implementation plans, assess risk, write the code, open pull requests, and — if you give it the go-ahead — merge and clean up. Human input is only required when the pipeline flags something as high-risk.
+
+## Quick Start
+
+1. **Install the marketplace** (once per machine):
+   ```bash
+   /plugin marketplace add https://github.com/schmimran/claude-skills
+   ```
+
+2. **Create the required labels** on your target repository (once per repo):
+   ```bash
+   gh label create "feature - ready for claude" --color 0E8A16 --description "Scoped and ready for automated planning"
+   gh label create "feature - planned" --color 1D76DB --description "Implementation plan posted as comment"
+   gh label create "feature - human review" --color D93F0B --description "Flagged for human review (high-risk or failed)"
+   gh label create "feature - in progress" --color FBCA04 --description "Branch created, implementation underway"
+   gh label create "feature - complete" --color 0E8A16 --description "PR created and code-reviewed"
+   ```
+
+3. **Label one or more issues** with `feature - ready for claude`.
+
+4. **Run the pipeline** from a Claude Code session in or targeting your repo:
+   ```
+   /feature-creator owner/repo
+   ```
+   Or, if your current directory is already the target repo:
+   ```
+   /feature-creator
+   ```
+
+5. **Watch the output.** The pipeline prints a live summary as each phase completes. When it finishes, you'll see a table of every issue with its planning status, risk level, implementation result, and PR link. By default, the pipeline pauses before merging the release branch and asks for your confirmation. Pass `--auto-merge` to skip the pause.
+
+## Prerequisites
+
+1. **GitHub CLI** must be installed and authenticated:
+   ```bash
+   gh auth status
+   ```
+
+2. **Labels** must exist on the target repository (see step 2 in Quick Start above).
 
 ## Architecture
 
 | Component | Type | Model | Description |
 |-----------|------|-------|-------------|
-| `feature-creator` | Command | (inherits) | Full pipeline: plan, review, implement, PR |
+| `feature-creator` | Command | (inherits) | Full pipeline: plan, review, implement, merge, clean up |
 | `feature-planner` | Agent | sonnet | Fetch labeled issues, analyze repo, post implementation plans |
 | `feature-reviewer` | Agent | sonnet | Review plans for risk, flag dangerous ones, create combined plan |
 | `feature-implementer` | Agent | opus | Create branches, write code, run tests, open PRs |
 
 The command orchestrates the three agents in sequence. Agents are not independently invocable — use the command to run the full pipeline.
 
-## Pipeline Overview
+## Pipeline
 
 ```
 GitHub Issues                    Pipeline                            Output
@@ -27,9 +65,20 @@ GitHub Issues                    Pipeline                            Output
                             feature-implementer agent
                         (branch, code, test, PR) ----------> Pull requests
                                     |                         opened
-                              Release branch
-                        (links all feature PRs) ------------> Integration PR
+                              Merge & cleanup
+                        (feature PRs → release PR) ---------> Merged + branches
+                                                              deleted
 ```
+
+The pipeline moves through four phases:
+
+**Phase 1 — Planning**: The planner agent reads each labeled issue, explores the target codebase, and posts a structured implementation plan as a comment. Issues that are too vague or reference non-existent files are flagged for human review.
+
+**Phase 2 — Review**: The reviewer agent reads each plan, scores it against a risk rubric, and flags anything high-risk for human review. For approved features, it produces a combined plan with implementation order and conflict notes.
+
+**Phase 3 — Implementation**: The implementer agent works through approved features one at a time. For each: it creates a branch, writes the code, runs tests (with up to 3 retry attempts), follows the merge checklist (`/simplify` + `/code-review`), and opens a PR.
+
+**Phase 4 — Merge and Cleanup**: Feature PRs are merged in implementation order. The release branch PR is created linking all features. If the session is in plan mode, the pipeline pauses here for your confirmation. Otherwise it merges automatically, then deletes all feature branches (local and remote), pulls main, and removes any worktree.
 
 ### Label Lifecycle
 
@@ -41,21 +90,48 @@ ready for claude  -->  planned  -->  in progress  -->  complete
                           +-> human review <-+
 ```
 
-## Prerequisites
+| Label | Set by | Meaning |
+|-------|--------|---------|
+| `feature - ready for claude` | Human | Issue is scoped and ready for automated planning |
+| `feature - planned` | feature-planner agent | Plan posted as issue comment |
+| `feature - human review` | feature-reviewer or feature-implementer agent | Flagged as high-risk or implementation failed |
+| `feature - in progress` | feature-implementer agent | Branch created, coding underway |
+| `feature - complete` | feature-implementer agent | PR created and code-reviewed |
 
-1. **GitHub CLI** must be installed and authenticated:
-   ```bash
-   gh auth status
-   ```
+## Pausing Before Merge
 
-2. **Labels** must exist on the target repository. Run these once per repo:
-   ```bash
-   gh label create "feature - ready for claude" --color 0E8A16 --description "Scoped and ready for automated planning"
-   gh label create "feature - planned" --color 1D76DB --description "Implementation plan posted as comment"
-   gh label create "feature - human review" --color D93F0B --description "Flagged for human review (high-risk or failed)"
-   gh label create "feature - in progress" --color FBCA04 --description "Branch created, implementation underway"
-   gh label create "feature - complete" --color 0E8A16 --description "PR created and code-reviewed"
-   ```
+By default, the pipeline pauses after merging all feature PRs and creating the release branch PR. It prints the release PR link and asks for your confirmation before merging. This gives you a final review opportunity before the changes land on main.
+
+To skip the pause and run the full pipeline end-to-end without stopping, pass `--auto-merge`:
+
+```
+/feature-creator owner/repo --auto-merge
+```
+
+In autonomous mode, feature PRs are merged in implementation order, the release branch is merged, branches are deleted, and the session is cleaned up — all without prompting. Use this for scheduled runs or when you're confident in the pipeline's output.
+
+In either mode, features flagged as high-risk during Phase 2 are never automatically merged — they always require human intervention.
+
+## Batch Size and Concurrency
+
+The pipeline warns if more than 5 issues are labeled `feature - ready for claude` at once. This warning is **advisory only** — agents will process all of them (up to 20 per run). To limit a batch, manually remove the trigger label from lower-priority issues before running.
+
+**Do not run multiple instances against the same repository simultaneously.** This pipeline is single-operator tooling.
+
+## Error Recovery
+
+If the pipeline crashes or is interrupted while an issue is labeled `feature - in progress`, that issue will be skipped on the next run (agents only query for `feature - planned`). To recover:
+
+```bash
+gh issue edit <NUMBER> --remove-label "feature - in progress" --add-label "feature - planned"
+```
+
+Then delete the orphaned branch if one was created:
+
+```bash
+git branch -D feature/<NUMBER>-<slug>
+git push origin --delete feature/<NUMBER>-<slug>
+```
 
 ## Usage
 
@@ -82,6 +158,22 @@ Prompt: "Run /feature-creator <OWNER/REPO>"
 ```
 
 Use the `/schedule` skill or `create_scheduled_task` tool to set this up.
+
+## Development Notes
+
+To test changes to agents or commands locally without installing from GitHub:
+
+```bash
+# Load the plugin directly from your local checkout
+claude --plugin-dir /path/to/claude-skills/plugins/feature-creator
+
+# The command is then available as:
+/feature-creator
+```
+
+**Plan comment markers**: Plans posted by the planner begin with `<!-- claude-feature-planner-v1 -->` and combined plans from the reviewer begin with `<!-- claude-feature-reviewer-v1 -->`. These markers are how downstream agents locate the right comment programmatically. If you modify the plan format, update the marker version and update the extraction logic in the relevant agent.
+
+For plugin structure conventions, authoring reference, and the checklist for adding new plugins, see [CLAUDE.md](../../CLAUDE.md).
 
 ## License
 

--- a/plugins/feature-creator/agents/feature-implementer.md
+++ b/plugins/feature-creator/agents/feature-implementer.md
@@ -129,7 +129,7 @@ git push origin release/<YYYY-MM-DD>
 ```
 
 Do **not** create the release PR here. The orchestrator (feature-creator command)
-is responsible for creating and merging the release PR, handling the plan-mode
+is responsible for creating and merging the release PR, handling the merge
 checkpoint, and running cleanup. Report the release branch name in your output
 summary so the orchestrator can find it.
 

--- a/plugins/feature-creator/agents/feature-implementer.md
+++ b/plugins/feature-creator/agents/feature-implementer.md
@@ -1,9 +1,10 @@
 ---
 name: feature-implementer
-description: Implements approved features by creating branches, writing code, running tests, following the merge checklist, and opening PRs, then creates a release branch linking all feature PRs
+description: Implements approved features on branches, runs tests, opens PRs, and creates a release branch
 tools: Bash, Read, Write, Edit, Grep, Glob, Agent, TodoWrite
 model: opus
 color: green
+disable-model-invocation: true
 ---
 
 # Feature Implementer
@@ -94,14 +95,7 @@ If tests or build fail:
 ### 2d. Follow Merge Checklist
 
 Follow the steps in `merge-checklist.md` (in the `references/` directory of
-this plugin):
-
-1. Run `/simplify` on all changed files
-2. Stage and commit changes
-3. Push the branch
-4. Create a PR using the template in `pr-template.md`
-5. Run `/code-review` on the PR
-6. If code review finds issues, fix them, commit, push, and re-review
+this plugin).
 
 ### 2e. Update Issue
 
@@ -127,28 +121,17 @@ git checkout main
 
 ## Step 3: Create Release Branch
 
-After all features are implemented:
+After all features are implemented, create and push the release branch:
 
 ```
 git checkout -b release/<YYYY-MM-DD> main
+git push origin release/<YYYY-MM-DD>
 ```
 
-Create a PR for the release branch. Always use `--body-file` to avoid shell
-injection:
-```
-cat > /tmp/release-pr.md << 'RELEASE_EOF'
-<RELEASE_BODY>
-RELEASE_EOF
-gh pr create --repo <OWNER/REPO> --title "Release <YYYY-MM-DD>" --body-file /tmp/release-pr.md
-```
-
-The release PR body should list all feature PRs with links:
-```
-## Features in this release
-
-- #<PR_NUMBER> — <Feature title> (closes #<ISSUE_NUMBER>)
-- #<PR_NUMBER> — <Feature title> (closes #<ISSUE_NUMBER>)
-```
+Do **not** create the release PR here. The orchestrator (feature-creator command)
+is responsible for creating and merging the release PR, handling the plan-mode
+checkpoint, and running cleanup. Report the release branch name in your output
+summary so the orchestrator can find it.
 
 ## Error Recovery
 
@@ -177,10 +160,12 @@ If implementation or verification fails for a feature after exhausting retries:
 
 ## Output
 
-When finished, print a summary:
+When finished, print a summary that includes:
 
 | Issue | Title | Result | PR |
 |-------|-------|--------|----|
 | #N | Title | Implemented / Failed: <reason> | #PR or — |
 
-If a release branch was created, print its PR link.
+Also report:
+- The release branch name (e.g., `release/2026-04-05`) if created
+- The list of created PR numbers in implementation order (the orchestrator merges these in Phase 4)

--- a/plugins/feature-creator/agents/feature-planner.md
+++ b/plugins/feature-creator/agents/feature-planner.md
@@ -1,9 +1,10 @@
 ---
 name: feature-planner
-description: Fetches GitHub issues labeled "feature - ready for claude", analyzes the target repo's context and codebase, then posts a detailed implementation plan as a comment on each issue
+description: Analyzes GitHub issues labeled "feature - ready for claude" and posts implementation plans as comments
 tools: Bash, Read, Grep, Glob, Agent, TodoWrite
 model: sonnet
 color: blue
+disable-model-invocation: true
 ---
 
 # Feature Planner

--- a/plugins/feature-creator/agents/feature-reviewer.md
+++ b/plugins/feature-creator/agents/feature-reviewer.md
@@ -1,9 +1,10 @@
 ---
 name: feature-reviewer
-description: Reviews planned features for risk, flags high-risk items for human review, and produces a combined implementation plan for approved features
+description: Assesses planned features for risk and produces a combined implementation plan for approved features
 tools: Bash, Read, Grep, Glob, Agent, TodoWrite
 model: sonnet
 color: yellow
+disable-model-invocation: true
 ---
 
 # Feature Reviewer
@@ -103,16 +104,7 @@ Structure the combined plan as:
 
 Use the Agent tool to spawn a review subagent. Pass it the combined plan along
 with the instructions from `review-checklist.md` (in the `references/` directory
-of this plugin).
-
-The subagent should review for:
-- Dependency ordering correctness
-- Missing test coverage
-- Convention violations
-- Scope concerns
-- Anything the planner may have missed
-
-Incorporate the subagent's feedback into the final plan.
+of this plugin). Incorporate the subagent's feedback into the final plan.
 
 ## Step 7: Post Final Plan
 

--- a/plugins/feature-creator/commands/feature-creator.md
+++ b/plugins/feature-creator/commands/feature-creator.md
@@ -1,6 +1,8 @@
 ---
+name: feature-creator
 description: End-to-end feature pipeline — plans, reviews, and implements GitHub issues labeled "feature - ready for claude"
-argument-hint: "[repo-owner/repo-name]"
+argument-hint: "[repo-owner/repo-name] [--auto-merge]"
+disable-model-invocation: true
 ---
 
 # Feature Creator
@@ -12,6 +14,7 @@ take GitHub issues from labeled requests through to merged pull requests.
 1. **feature-planner** — Fetch issues, analyze repo, post implementation plans
 2. **feature-reviewer** — Assess risk, flag dangerous features, create combined plan
 3. **feature-implementer** — Create branches, write code, run tests, open PRs
+4. **Merge and cleanup** — Merge feature PRs in order, merge release branch, clean up
 
 ## Prerequisites
 
@@ -21,10 +24,11 @@ take GitHub issues from labeled requests through to merged pull requests.
    ```
    If not authenticated, stop and tell the user to run `gh auth login`.
 
-2. Resolve the target repository:
-   - If `$ARGUMENTS` is provided, use it as the `OWNER/REPO` identifier.
-   - Otherwise, detect from the current directory: `gh repo view --json nameWithOwner -q .nameWithOwner`
+2. Resolve the target repository and flags:
+   - Parse `$ARGUMENTS`: extract `OWNER/REPO` and check for the `--auto-merge` flag.
+   - If no `OWNER/REPO` is given, detect from the current directory: `gh repo view --json nameWithOwner -q .nameWithOwner`
    - If neither works, stop and ask the user for the repository.
+   - Note whether `--auto-merge` was passed — this controls Phase 4 behavior.
 
 3. Verify required labels exist on the repo:
    ```
@@ -32,7 +36,7 @@ take GitHub issues from labeled requests through to merged pull requests.
    ```
    Check for: `feature - ready for claude`, `feature - planned`,
    `feature - human review`, `feature - in progress`, `feature - complete`.
-   If any are missing, print the `gh label create` commands from the README
+   If any are missing, print the `gh label create` commands from the plugin README
    and stop.
 
 ## Batch Size Guard
@@ -69,6 +73,7 @@ Use the Agent tool to launch the feature-reviewer agent with the following promp
 Wait for the agent to complete. Check its output:
 - Note which features were approved and which were flagged for human review.
 - If all features were flagged, stop and report.
+- Record the implementation order from the reviewer's output — you will need it in Phase 4.
 
 ## Phase 3: Implementation
 
@@ -76,7 +81,92 @@ Use the Agent tool to launch the feature-implementer agent with the following pr
 
 > You are the feature-implementer. Target repository: <OWNER/REPO>
 
-Wait for the agent to complete. Collect its output for the summary.
+Wait for the agent to complete. Collect its output:
+- Record each feature PR number and the release branch name.
+- Note any features that failed implementation.
+
+## Phase 4: Merge and Cleanup
+
+Only proceed if at least one feature PR was successfully created.
+
+### 4a. Check auto-merge flag
+
+If `--auto-merge` was passed in `$ARGUMENTS`, proceed automatically through all
+steps without pausing. Otherwise, pause before merging the release branch (4c)
+to give the user a final review opportunity.
+
+### 4b. Merge feature PRs
+
+For each PR in the Phase 3 output list (which already reflects implementation order):
+
+```
+gh pr merge <PR_NUMBER> --repo <OWNER/REPO> --squash --delete-branch
+```
+
+If a merge fails, post a comment on the corresponding issue, change its label to
+`feature - human review`, and continue with the next PR.
+
+### 4c. Create and merge the release branch PR
+
+Create the release branch PR using `--body-file` to avoid shell injection:
+
+```
+cat > /tmp/release-pr-body.md << 'RELEASE_EOF'
+## Features in this release
+
+- #<PR_NUMBER> — <Feature title> (closes #<ISSUE_NUMBER>)
+...
+
+Automated by feature-creator.
+RELEASE_EOF
+gh pr create --repo <OWNER/REPO> --base main --head release/<YYYY-MM-DD> --title "Release <YYYY-MM-DD>" --body-file /tmp/release-pr-body.md
+```
+
+Only include features that were successfully merged in the release PR body.
+
+**If `--auto-merge` was NOT passed**: Stop here. Print the release PR link and ask:
+> All feature PRs have been merged. Release PR: <URL>
+> Respond to confirm and I will merge the release branch and clean up.
+
+Wait for explicit user confirmation before continuing to step 4d.
+
+**If `--auto-merge` was passed**: Proceed immediately to step 4d.
+
+### 4d. Merge the release branch
+
+```
+gh pr merge <RELEASE_PR_NUMBER> --repo <OWNER/REPO> --squash
+```
+
+### 4e. Cleanup
+
+Follow the global cleanup conventions from `~/.claude/CLAUDE.md`:
+
+```
+git checkout main && git pull
+
+# Delete remote feature branches (always run — --delete-branch in 4b handles
+# GitHub's remote ref but local tracking refs require explicit cleanup)
+git push origin --delete feature/<N>-<slug>   # for each feature branch
+
+# Delete local feature branches
+git branch -D feature/<N>-<slug>              # for each feature branch
+
+# Delete release branch (local and remote)
+git branch -D release/<YYYY-MM-DD>
+git push origin --delete release/<YYYY-MM-DD>
+
+# If running in a git worktree, remove it
+git worktree remove .claude/worktrees/<name>
+```
+
+### 4f. Memory
+
+Per the global "After a feature is complete" conventions: if any non-obvious
+patterns, architectural decisions, or environment variables were introduced in
+the target repository during this run, save them to Claude Code memory.
+
+Do not save ephemeral details (PR numbers, branch names, issue counts).
 
 ## Summary
 
@@ -94,10 +184,10 @@ After all phases complete (or if the pipeline stops early), print a final report
 - Planned: X
 - Flagged for human review: X
 - Implemented: X
-- PRs created: X
+- Merged: X
 
-### Release Branch
-<PR link if created, or "Not created (no features implemented)">
+### Release
+<Release PR link and merge status, or "Not created (no features implemented)">
 ```
 
 ## Error Handling
@@ -108,3 +198,4 @@ After all phases complete (or if the pipeline stops early), print a final report
   The pipeline continues with remaining features.
 - If Phase 1 produces no planned features, stop before Phase 2.
 - If Phase 2 flags all features, stop before Phase 3.
+- If Phase 3 produces no PRs, skip Phase 4.


### PR DESCRIPTION
## Summary

- **Root README**: Added "How It Works" section, version column in plugin table, plain-English description of feature-creator for lay visitors
- **Plugin README**: Added Quick Start section, expanded Pipeline section with phase descriptions, moved Label Lifecycle table + Batch Size/Concurrency/Error Recovery from CLAUDE.md, replaced plan mode detection with `--auto-merge` flag documentation
- **CLAUDE.md**: Removed duplicated Feature-Creator Pipeline section, expanded Conventions (markers, branching, commit format), expanded Behavioral Rules from 2 to 8, updated frontmatter tables to include `disable-model-invocation` and corrected `name` field requirement for commands
- **feature-creator command**: Added `name` + `disable-model-invocation`, added Phase 4 (merge feature PRs, release branch checkpoint, cleanup, memory) with explicit `--auto-merge` flag replacing unreliable plan mode detection
- **Agents**: Added `disable-model-invocation: true` and shortened descriptions to all three agents; removed inline re-enumeration of reference file content; moved release PR creation from implementer to orchestrator

## Test plan

- [ ] Read root README as a first-time visitor — should understand the project without prior context
- [ ] Follow Quick Start steps in plugin README — all commands should be accurate and complete
- [ ] Verify CLAUDE.md cross-references: Prerequisites → plugin README for label commands, Adding a New Plugin checklist step 4 → root README catalog
- [ ] Verify all agent frontmatter has `disable-model-invocation: true`
- [ ] Verify feature-creator command has `name: feature-creator` and `disable-model-invocation: true`
- [ ] Check Phase 4 in feature-creator command: `--auto-merge` flag logic is clear, cleanup runs unconditionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)