### PR TITLE
fix: use relative-path sources for same-repo plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,26 +6,18 @@
   "plugins": [
     {
       "name": "feature-creator",
-      "source": {
-        "source": "github",
-        "repo": "schmimran/claude-skills",
-        "path": "plugins/feature-creator"
-      },
+      "source": "./plugins/feature-creator",
       "description": "Feature development pipeline — GitHub issues to implementation plans to PRs.",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "author": {
         "name": "schmimran"
       }
     },
     {
       "name": "security-scanner",
-      "source": {
-        "source": "github",
-        "repo": "schmimran/claude-skills",
-        "path": "plugins/security-scanner"
-      },
+      "source": "./plugins/security-scanner",
       "description": "Multi-tool security audit for Node.js web apps — files findings as GitHub Issues with deduplication and auto-close.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "schmimran"
       }

--- a/plugins/feature-creator/.claude-plugin/plugin.json
+++ b/plugins/feature-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "feature-creator",
   "description": "Feature development pipeline — GitHub issues to implementation plans to PRs.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "schmimran"
   }

--- a/plugins/security-scanner/.claude-plugin/plugin.json
+++ b/plugins/security-scanner/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "security-scanner",
   "description": "Multi-tool security audit for Node.js web apps — files findings as GitHub Issues with deduplication and auto-close.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "schmimran"
   }


### PR DESCRIPTION
## Summary
- Swap both plugin `source` blocks in `.claude-plugin/marketplace.json` from `github`+`path` (invalid combo) to relative paths
- Bump versions in lockstep: feature-creator 0.4.0→0.4.1, security-scanner 0.1.0→0.1.1

## Why
Installing either plugin failed with `git@github.com: Permission denied (publickey)`. The `github` source type doesn't accept a `path` field — it was ignored and the CLI tried to re-clone the whole marketplace repo over SSH. Relative paths are the documented pattern for plugins living in the same repo as the marketplace.

## Test plan
- [x] `claude plugin validate .` passes
- [ ] `/plugin marketplace add schmimran/claude-skills` + `/plugin install feature-creator@claude-skills` succeeds from a clean shell
- [ ] `/plugin install security-scanner@claude-skills` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)