### PR TITLE
feat: add Supabase security auditing to security-scanner v0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,8 +16,8 @@
     {
       "name": "security-scanner",
       "source": "./plugins/security-scanner",
-      "description": "Multi-tool security audit for Node.js web apps — files findings as GitHub Issues with deduplication and auto-close.",
-      "version": "0.1.1",
+      "description": "Multi-tool security audit for Node.js web apps and Supabase projects — files findings as GitHub Issues with deduplication and auto-close.",
+      "version": "0.2.0",
       "author": {
         "name": "schmimran"
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,13 +31,14 @@ plugins/
       merge-checklist.md          # Pre-merge steps
       pr-template.md              # PR body template
     README.md                     # Plugin-specific documentation
-  security-scanner/               # Plugin: multi-tool security audit for Node.js
+  security-scanner/               # Plugin: multi-tool security audit for Node.js + Supabase
     .claude-plugin/
       plugin.json                 # Plugin manifest
     commands/
-      security-scanner.md         # Orchestrator command — chains the three agents
+      security-scanner.md         # Orchestrator command — chains the four agents
     agents/
-      security-runner.md          # Agent: install tools, run scans, emit JSON report
+      security-runner.md          # Agent: install tools, run Node.js scans, emit JSON report
+      security-supabase-auditor.md # Agent: query Supabase advisor API + scan migrations/config.toml
       security-triager.md         # Agent: fingerprint findings, file new issues, skip duplicates
       security-closer.md          # Agent: close resolved findings
     references/
@@ -46,6 +47,8 @@ plugins/
       issue-template.md           # Template for filed GitHub Issues
       suppression-guide.md        # How to suppress false positives
       tool-install-guide.md       # Tool installation and failure handling
+      supabase-audit-guide.md     # Supabase detection, advisor API, static scan rules
+      supabase-rule-catalog.md    # Catalog of Supabase rules with severity + remediation
     README.md                     # Plugin-specific documentation
 ```
 

--- a/plugins/security-scanner/.claude-plugin/plugin.json
+++ b/plugins/security-scanner/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "security-scanner",
-  "description": "Multi-tool security audit for Node.js web apps — files findings as GitHub Issues with deduplication and auto-close.",
-  "version": "0.1.1",
+  "description": "Multi-tool security audit for Node.js web apps and Supabase projects — files findings as GitHub Issues with deduplication and auto-close.",
+  "version": "0.2.0",
   "author": {
     "name": "schmimran"
   }

--- a/plugins/security-scanner/README.md
+++ b/plugins/security-scanner/README.md
@@ -1,8 +1,9 @@
 # security-scanner
 
-Runs a multi-tool security audit of a Node.js web application and files
-findings as labeled GitHub Issues.  Deduplicates by fingerprint, files new
-issues for novel findings, and auto-closes issues for resolved ones.
+Runs a multi-tool security audit of a Node.js web application and (when
+present) its Supabase project, and files findings as labeled GitHub Issues.
+Deduplicates by fingerprint, files new issues for novel findings, and
+auto-closes issues for resolved ones.
 
 ## Quick Start
 
@@ -40,15 +41,22 @@ issues for novel findings, and auto-closes issues for resolved ones.
 
 - **Node.js** with `npm` available in the shell
 - **GitHub CLI** installed and authenticated (`gh auth status`)
+- **jq** on PATH — used by the orchestrator to merge findings.  Install with
+  `brew install jq` (macOS) or `apt-get install jq` / `dnf install jq` (Linux).
 - **Internet access** for semgrep rule configs (fetched at runtime)
 - Required labels created on the target repository (see Quick Start above)
+- **Optional, for Supabase auditing**: `SUPABASE_ACCESS_TOKEN` exported in the
+  shell.  Without it, Supabase auditing falls back to static-only scanning of
+  `supabase/migrations` and `supabase/config.toml`.  See Supabase Auditing
+  below.
 
 ## Architecture
 
 | Component | Type | Model | Description |
 |-----------|------|-------|-------------|
-| `security-scanner` | Command | (inherits) | Orchestrates the three-agent pipeline |
-| `security-runner` | Agent | sonnet | Installs tools, runs scans, emits JSON report |
+| `security-scanner` | Command | (inherits) | Orchestrates the four-agent pipeline |
+| `security-runner` | Agent | sonnet | Installs tools, runs Node.js scans, emits JSON report |
+| `security-supabase-auditor` | Agent | sonnet | Queries Supabase advisor API + scans migrations/config.toml |
 | `security-triager` | Agent | sonnet | Fingerprints findings, files new issues, skips duplicates |
 | `security-closer` | Agent | sonnet | Closes GitHub Issues for resolved findings |
 
@@ -57,21 +65,32 @@ issues for novel findings, and auto-closes issues for resolved ones.
 ```
 Target Repo
     |
-    v
-security-runner
-(npm audit + semgrep + nodejsscan)
-    |
-    v
-/tmp/security-findings.json
-    |
-    v
-security-triager                    security-closer
-(fingerprint → compare open        (compare open issues
- issues → file new | skip           → close resolved)
- duplicates | skip suppressed)
-    |                                     |
-    v                                     v
-GitHub Issues filed              GitHub Issues closed
+    +----------------------------+
+    v                            v
+security-runner          security-supabase-auditor
+(npm audit + semgrep    (advisor API + static scan of
+ + nodejsscan)           migrations + config.toml)
+    |                            |
+    v                            v
+/tmp/security-findings   /tmp/security-findings-
+       .json                  supabase.json
+    \                          /
+     \                        /
+      v                      v
+       jq merge (orchestrator)
+                |
+                v
+     /tmp/security-findings.json
+                |
+    +-----------+-----------+
+    v                       v
+security-triager     security-closer
+(file new | skip     (close resolved,
+ duplicates |         skip suppressed)
+ skip suppressed)
+    |                       |
+    v                       v
+GitHub Issues filed    GitHub Issues closed
 ```
 
 ## Modes
@@ -90,6 +109,10 @@ GitHub Issues filed              GitHub Issues closed
 | OWASP Top 10 (injection, SSRF, broken auth) | semgrep p/owasp-top-ten |
 | Node.js-specific patterns | semgrep p/nodejs |
 | Node-specific web vulnerabilities | nodejsscan |
+| Supabase RLS misconfiguration | advisor API + migration scan |
+| `SECURITY DEFINER` hygiene, `auth.users` exposure, extensions in `public` | advisor API + migration scan |
+| Supabase auth hardening (leaked-password protection, MFA, OTP expiry, weak passwords) | advisor API + config.toml scan |
+| API-exposed schema overreach | config.toml scan |
 
 ## Deduplication
 
@@ -119,6 +142,72 @@ against the current findings.  Issues whose fingerprint no longer appears in
 the scan output are auto-closed with a comment noting the timestamp.  Suppressed
 issues are never auto-closed.
 
+## Supabase Auditing
+
+If the target repo uses Supabase, the scanner adds a dedicated auditor covering
+the data model (RLS coverage, policies, `SECURITY DEFINER` hygiene,
+`auth.users` exposure, storage buckets, extensions in `public`) and
+configuration (auth hardening, API schemas).
+
+### Detection
+
+The Supabase auditor runs automatically if any of these signals are present
+(no flag to enable, no flag to disable):
+
+1. `supabase/config.toml` exists.
+2. `@supabase/supabase-js` is in `package.json`.
+3. `SUPABASE_URL` is set in any `.env*` file.
+4. `supabase/migrations/` has at least one `.sql` file.
+
+### Two data sources
+
+The auditor prefers the **Supabase advisor API**, which is authoritative for
+live project state:
+
+```
+GET https://api.supabase.com/v1/projects/{ref}/advisors?type=security
+```
+
+To enable the API path, export:
+
+```bash
+# Create at https://supabase.com/dashboard/account/tokens
+export SUPABASE_ACCESS_TOKEN=sbp_...
+```
+
+The project ref is auto-detected in this order:
+`SUPABASE_PROJECT_REF` → `project_id` in `supabase/config.toml` →
+`SUPABASE_URL` subdomain from `.env*`.
+
+If the token or ref is missing, or the API returns a non-200 response, the
+auditor logs the issue and falls back to **static scanning** of
+`supabase/migrations/*.sql` and `supabase/config.toml`.  Seed files
+(`supabase/seed.sql`) and tests under `supabase/tests/**` are excluded — they
+routinely contain allow-all policies that are intentional for local dev.
+
+Both paths produce findings with the same schema.  Advisor findings carry
+Supabase's official remediation URL directly in the filed issue's
+Recommendation section.  For advisor rules with empty `remediation`, a local
+catalog (`references/supabase-rule-catalog.md`) provides the fallback fix
+text.
+
+### Severity highlights
+
+- `rls_disabled_in_public`, allow-all policies, `auth.users` exposed → **critical**
+- `SECURITY DEFINER` without pinned `search_path`, extensions in `public`,
+  leaked-password protection disabled → **high**
+- RLS enabled but no policies, long OTP expiry, weak password policy → **medium**
+
+See `references/finding-severity-rubric.md` for the full mapping.
+
+### What about `config.toml`?
+
+Local `supabase/config.toml` reflects **developer intent** for local
+environments.  Production auth config lives in the Supabase dashboard and
+comes through the advisor API.  Findings from config.toml are labeled as
+such in the issue body so you don't assume a config.toml fix addresses
+production.
+
 ## Scheduling
 
 Wrap in a cron job for weekly full scans:
@@ -129,12 +218,15 @@ Wrap in a cron job for weekly full scans:
   claude -p "/security-scanner owner/repo full" >> ~/security-scan.log 2>&1
 ```
 
-## Known Limitations (v0.1)
+## Known Limitations
 
-- Air-gapped environments not supported (semgrep requires internet for rule configs)
-- DAST (runtime/dynamic analysis) not included — static analysis only
+- Air-gapped environments not supported (semgrep requires internet for rule
+  configs; the Supabase advisor API also requires outbound internet)
+- DAST (runtime/dynamic analysis) not included — static + advisor-level only
 - Infrastructure and environment config not scanned
 - Third-party API trust surfaces not covered
+- Supabase Edge Functions are scanned only to the extent that semgrep covers
+  their `.ts` / `.js` sources — no Supabase-specific runtime checks
 
 ## License
 

--- a/plugins/security-scanner/agents/security-supabase-auditor.md
+++ b/plugins/security-scanner/agents/security-supabase-auditor.md
@@ -1,0 +1,306 @@
+---
+name: security-supabase-auditor
+description: Audits Supabase data model and configuration for security issues — queries the Supabase advisor API and scans local migrations and config.toml
+tools: Bash, Read, Glob, Grep, TodoWrite
+model: sonnet
+color: red
+disable-model-invocation: true
+---
+
+# Security Supabase Auditor
+
+You audit a Supabase project for security issues in the data model (RLS, policies,
+`SECURITY DEFINER` hygiene, `auth.*` exposure) and configuration (auth hardening,
+API-exposed schemas).  You write structured findings to
+`/tmp/security-findings-supabase.json` for the orchestrator to merge with
+`security-runner` output.
+
+Read `supabase-audit-guide.md`, `supabase-rule-catalog.md`, `fingerprint-spec.md`,
+and `finding-severity-rubric.md` in the `references/` directory of this plugin
+before proceeding.  They define detection rules, severity overrides, remediation
+fallback, and fingerprint formats.
+
+## Step 1: Clean up stale files from prior runs
+
+```bash
+rm -f /tmp/sec-supabase-advisors.json
+```
+
+## Step 2: Detect Supabase usage
+
+Check, in order — any one match is sufficient:
+
+1. `supabase/config.toml` exists.
+2. `@supabase/supabase-js` appears in `package.json` (`dependencies` or
+   `devDependencies`).
+3. `SUPABASE_URL` is set in any `.env*` file at the repo root.
+4. `supabase/migrations/` exists and has at least one `.sql` file.
+
+If none match, write an empty findings file and stop:
+
+```bash
+cat > /tmp/security-findings-supabase.json <<EOF
+{"scan_timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)", "mode": "<MODE>", "repo": "<OWNER/REPO>", "findings": []}
+EOF
+echo "Supabase not detected — skipping."
+```
+
+Then print the summary table with all zeros and exit.
+
+## Step 3: Resolve project ref
+
+Try in order.  First non-empty result wins.  Log which source was used.
+
+1. `$SUPABASE_PROJECT_REF`
+2. `project_id` in `supabase/config.toml` (look for a line like
+   `project_id = "abcdef..."`)
+3. Subdomain of `SUPABASE_URL` from `.env*` (`https://<ref>.supabase.co`).
+   Use `grep -h '^SUPABASE_URL=' .env* 2>/dev/null | head -1`.
+
+Store as `PROJECT_REF`.  If unresolved, log and proceed to static path only:
+
+```
+No Supabase project ref found — skipping advisor API, running static-only.
+```
+
+## Step 4: Resolve access token
+
+Only source: `$SUPABASE_ACCESS_TOKEN`.  If unset:
+
+```
+SUPABASE_ACCESS_TOKEN not set — skipping advisor API, running static-only.
+```
+
+Never echo the token value.  Never write it to a file.
+
+## Step 5: Call Supabase advisor API (if ref + token both present)
+
+If either `PROJECT_REF` or `SUPABASE_ACCESS_TOKEN` is unset, skip directly to
+Step 6 (static path).
+
+```bash
+HTTP_STATUS=$(curl -sS -o /tmp/sec-supabase-advisors.json -w '%{http_code}' \
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+  "https://api.supabase.com/v1/projects/${PROJECT_REF}/advisors?type=security")
+```
+
+- `200`: proceed to Step 5 (parse advisors).
+- Non-200: log the status plus first 200 chars of the body (token is not in
+  the body — safe to log).  Record `supabase-advisor-api` in `skipped_tools`.
+  Skip to Step 6 (static path).
+
+Example non-200 log:
+
+```
+Supabase advisor API returned 403 — skipping advisor findings.
+Response: {"message":"missing scope: projects:read"}
+```
+
+## Step 6: Parse advisor findings
+
+For each advisor item in `/tmp/sec-supabase-advisors.json`:
+
+1. Extract `name`, `title`, `level`, `description`, `detail`, `remediation`,
+   `metadata`, `cache_key`.
+2. Resolve entity:
+   - `schema` = `metadata.schema` if present, else `public`.
+   - `entity` = first non-empty of `metadata.table`, `metadata.function`,
+     `metadata.view`, `metadata.name`.  Fallback: `"(unknown)"`.
+   - For `auth_config`-level advisors (leaked-password protection, OTP expiry,
+     MFA options, weak-password config): use `entity = "auth_config"` and
+     `schema = "auth"`.
+3. Determine `severity` using the named-rule overrides and fallback level
+   mapping in `finding-severity-rubric.md` (Supabase Findings section).
+4. Resolve `recommendation`:
+   - If `remediation` in the API response is non-empty → use it.
+   - Else look up `name` in `supabase-rule-catalog.md` → use
+     `remediation_url`.
+   - Else → `"See Supabase Database Advisor docs for <name>"` and log the
+     unknown rule name to terminal.
+5. Compose `message` = `description` + (if present) `"\n\n" + detail`.
+6. Compute fingerprint using the `supabase-advisor` canonical string defined
+   in `fingerprint-spec.md` (section "For Supabase advisor findings").
+7. Skip if `severity == low` (log to terminal, do not include in findings
+   array).
+
+Append the finding to the output `findings` array:
+
+```json
+{
+  "fingerprint": "<hex>",
+  "source": "supabase-advisor",
+  "rule_id": "<name>",
+  "file": null,
+  "line_start": null,
+  "line_end": null,
+  "severity": "<severity>",
+  "title": "<title>",
+  "message": "<message>",
+  "recommendation": "<recommendation>",
+  "cache_key": "<cache_key>",
+  "entity": "<schema>.<entity>"
+}
+```
+
+## Step 7: Static path — migrations scan
+
+Runs unconditionally whenever Supabase is detected, regardless of API success.
+
+Glob `supabase/migrations/*.sql`.  **Exclude**:
+
+- `supabase/seed.sql`, `supabase/seed.*.sql`
+- Anything under `supabase/tests/**`
+
+For each migration file, apply these detectors (case-insensitive regex).  All
+severities, remediation text, and fix URLs come from `supabase-rule-catalog.md`
+(the `Static rules` section).
+
+### Detector: `missing_rls`
+
+Find `CREATE TABLE` statements for tables in the `public` schema with no
+matching `ALTER TABLE <name> ENABLE ROW LEVEL SECURITY` later in the same
+file.  Extract the table name and line number of the `CREATE TABLE`.
+
+### Detector: `policy_allows_all`
+
+Find `CREATE POLICY` statements containing `USING (true)` or
+`WITH CHECK (true)`.
+
+### Detector: `security_definer_no_search_path`
+
+Find `CREATE FUNCTION ... SECURITY DEFINER` statements with no
+`SET search_path = ...` clause before the function body (`AS $$`).
+
+### Detector: `grant_to_anon`
+
+Find `GRANT <privs> ON ... TO anon` statements.
+
+### Detector: `view_references_auth_users`
+
+Find `CREATE VIEW` or `CREATE OR REPLACE VIEW` whose body (up to the
+terminating semicolon) contains `auth.users` or `auth.identities`.
+
+Severity and remediation text for each detector are in `supabase-rule-catalog.md`
+(Static rules section).
+
+### Finding schema for static matches
+
+For each match, compute:
+
+- `file`: relative path from repo root
+- `line_start`: line of the first match token
+- `line_end`: approximate end of the statement (line_start is fine if you
+  cannot determine it cheaply — line-band absorbs drift)
+- Fingerprint: use the `supabase-schema` canonical string defined in
+  `fingerprint-spec.md` (section "For Supabase static schema findings").
+
+Append:
+
+```json
+{
+  "fingerprint": "<hex>",
+  "source": "supabase-schema",
+  "rule_id": "<detector id>",
+  "file": "<relative path>",
+  "line_start": <n>,
+  "line_end": <n>,
+  "severity": "<severity from catalog>",
+  "title": "<catalog title>",
+  "message": "<catalog remediation_text>",
+  "recommendation": "<catalog remediation_url>",
+  "cache_key": null,
+  "entity": null
+}
+```
+
+## Step 8: Static path — config.toml scan
+
+If `supabase/config.toml` exists, parse it for these conditions (keys are the
+TOML paths):
+
+| rule_id | condition |
+|---|---|
+| `weak_password_policy` | `[auth] minimum_password_length` < 10 |
+| `signup_without_confirmation` | `[auth] enable_signup = true` AND `[auth.email] enable_confirmations = false` |
+| `api_schemas_overexposed` | `[api] schemas` contains any schema other than `public`, `graphql_public`, `storage` |
+
+Severity, remediation text, and remediation URLs for each rule are in
+`supabase-rule-catalog.md` (Static rules — config.toml source section).
+Production truth lives in the Supabase dashboard and comes through the advisor
+API — note this in the filed issue's message.
+
+For each match, compute the fingerprint using the `supabase-config` canonical
+string defined in `fingerprint-spec.md` (section "For Supabase config findings").
+
+Append:
+
+```json
+{
+  "fingerprint": "<hex>",
+  "source": "supabase-config",
+  "rule_id": "<rule_id>",
+  "file": "supabase/config.toml",
+  "line_start": <n>,
+  "line_end": <n>,
+  "severity": "medium",
+  "title": "<catalog title>",
+  "message": "<catalog remediation_text> (Note: this reflects local dev configuration; production auth settings live in the Supabase dashboard.)",
+  "recommendation": "<catalog remediation_url>",
+  "cache_key": null,
+  "entity": null
+}
+```
+
+## Step 9: Emit findings file
+
+Compose and write `/tmp/security-findings-supabase.json`:
+
+```json
+{
+  "scan_timestamp": "<ISO 8601>",
+  "mode": "<quick|full>",
+  "repo": "<OWNER/REPO>",
+  "skipped_tools": ["supabase-advisor-api"],
+  "findings": [ ... ]
+}
+```
+
+Include `skipped_tools` only when the advisor API was attempted and failed or
+was skipped due to missing token/ref.  Otherwise omit the field.
+
+Use a heredoc or `jq -n` to build the file — never interpolate finding text
+into a shell string directly.
+
+## Step 10: Output summary
+
+Print:
+
+```
+## Supabase Auditor Summary
+
+Detection: <detected | not-detected>
+API path: <ok | skipped-no-token | skipped-no-ref | skipped-<HTTP status>>
+Static path: <ran | skipped>
+
+### Findings
+
+| Source | Critical | High | Medium | Low |
+|--------|----------|------|--------|-----|
+| supabase-advisor | X | X | X | X |
+| supabase-schema  | X | X | X | X |
+| supabase-config  | X | X | X | X |
+| **Total**        | X | X | X | X |
+```
+
+State: `Supabase findings written to /tmp/security-findings-supabase.json`.
+
+## Safety notes
+
+- **Never log or persist `SUPABASE_ACCESS_TOKEN`.**  Do not echo it, do not
+  include it in any file, do not print it in error messages.
+- When logging non-200 API responses, include the status code and first ~200
+  chars of the body only.  The body contains error details from the API and
+  does not include the token.
+- When building finding JSON, prefer `jq -n` with `--arg` for any field
+  derived from advisor data (description, title, message) to avoid JSON
+  injection from unexpected characters.

--- a/plugins/security-scanner/agents/security-supabase-auditor.md
+++ b/plugins/security-scanner/agents/security-supabase-auditor.md
@@ -84,7 +84,7 @@ HTTP_STATUS=$(curl -sS -o /tmp/sec-supabase-advisors.json -w '%{http_code}' \
   "https://api.supabase.com/v1/projects/${PROJECT_REF}/advisors?type=security")
 ```
 
-- `200`: proceed to Step 5 (parse advisors).
+- `200`: proceed to Step 6 (parse advisors).
 - Non-200: log the status plus first 200 chars of the body (token is not in
   the body — safe to log).  Record `supabase-advisor-api` in `skipped_tools`.
   Skip to Step 6 (static path).

--- a/plugins/security-scanner/commands/security-scanner.md
+++ b/plugins/security-scanner/commands/security-scanner.md
@@ -7,13 +7,20 @@ disable-model-invocation: true
 
 # Security Scanner
 
-You are a security audit orchestrator.  You chain three agents to scan a Node.js
-application, deduplicate findings against open GitHub Issues, file new issues,
-and close resolved ones.
+You are a security audit orchestrator.  You chain four agents to scan a Node.js
+application (plus its Supabase project, if present), deduplicate findings
+against open GitHub Issues, file new issues, and close resolved ones.
 
 **Pipeline**:
-1. **security-runner** — install tools if needed, run scans, emit structured findings
-2. **security-triager** and **security-closer** run in parallel after the scan:
+1. **security-runner** and **security-supabase-auditor** run in parallel:
+   - **security-runner** — install tools if needed, run Node.js scans, emit
+     structured findings to `/tmp/security-findings.json`
+   - **security-supabase-auditor** — detect Supabase usage, call the Supabase
+     advisor API (if token + ref available), scan migrations and config.toml,
+     emit findings to `/tmp/security-findings-supabase.json`
+2. **Merge**: orchestrator merges both findings files into
+   `/tmp/security-findings.json` using `jq`.
+3. **security-triager** and **security-closer** run in parallel after the merge:
    - **security-triager** — fingerprint findings, compare against open issues,
      file new issues, skip duplicates
    - **security-closer** — compare open security issues against current findings,
@@ -21,27 +28,45 @@ and close resolved ones.
 
 ## Prerequisites
 
-1. Verify GitHub CLI authentication:
+1. Verify `jq` is installed (used to merge runner + Supabase findings):
+   ```
+   command -v jq
+   ```
+   If missing, stop and tell the user to install `jq` — `brew install jq` on
+   macOS, `apt-get install jq` or `dnf install jq` on Linux.
+
+2. Verify GitHub CLI authentication:
    ```
    gh auth status
    ```
    If not authenticated, stop and tell the user to run `gh auth login`.
 
-2. Parse `$ARGUMENTS`:
+3. Parse `$ARGUMENTS`:
    - Extract `OWNER/REPO` if provided.  If not, detect from current directory:
      `gh repo view --json nameWithOwner -q .nameWithOwner`
    - Extract mode: `full` or `quick`.  Default to `quick` if not specified.
    - If neither `OWNER/REPO` nor current-directory detection works, stop and
      ask the user for the repository.
 
-3. Verify the security label exists on the target repo:
+4. Verify the security label exists on the target repo:
    ```
    gh label list --repo <OWNER/REPO> --json name -q '.[].name'
    ```
    Check for: `security`, `security - suppressed`.
    If missing, print the create commands from the plugin README and stop.
 
-## Phase 1: Scan
+## Phase 1: Scan (parallel)
+
+Remove any stale findings files left by prior runs before starting:
+
+```bash
+rm -f /tmp/security-findings.json /tmp/security-findings-supabase.json \
+      /tmp/security-findings.merged.json /tmp/sec-supabase-advisors.json
+```
+
+Launch **security-runner** and **security-supabase-auditor** simultaneously —
+they write to different files and do not share state, so they are fully
+independent.  Use a single message with two Agent tool calls.
 
 Launch the **security-runner** agent with this prompt:
 
@@ -50,8 +75,41 @@ Launch the **security-runner** agent with this prompt:
 > Run the security scans and emit a structured JSON findings report to
 > /tmp/security-findings.json
 
-Wait for the agent to complete.  If the agent reports that no tools could be
-installed or all scans failed, stop and report.
+Launch the **security-supabase-auditor** agent with this prompt:
+
+> You are the security-supabase-auditor.  Target repository: <OWNER/REPO>
+> Mode: <MODE>
+> Detect Supabase usage.  If present, call the Supabase advisor API (when
+> SUPABASE_ACCESS_TOKEN and a project ref are available) and scan
+> supabase/migrations and supabase/config.toml statically.  Emit findings to
+> /tmp/security-findings-supabase.json
+
+Wait for both agents to complete.  If the runner reports that no tools could
+be installed or all scans failed, stop and report (Supabase findings alone
+are not a sufficient basis to continue — the pipeline assumes the Node.js
+scan ran).
+
+## Phase 1.5: Merge findings
+
+First verify the runner produced output — if `/tmp/security-findings.json`
+does not exist, the runner failed; stop and report.
+
+If `/tmp/security-findings-supabase.json` also exists, merge it in:
+
+```bash
+if [ -f /tmp/security-findings-supabase.json ]; then
+  jq -s '{scan_timestamp: .[0].scan_timestamp, mode: .[0].mode, repo: .[0].repo,
+          findings: ((.[0].findings // []) + (.[1].findings // [])),
+          skipped_tools: ((.[0].skipped_tools // []) + (.[1].skipped_tools // []))}' \
+    /tmp/security-findings.json /tmp/security-findings-supabase.json \
+    > /tmp/security-findings.merged.json && \
+  mv /tmp/security-findings.merged.json /tmp/security-findings.json
+fi
+```
+
+If the Supabase file is absent (non-Supabase repo), the runner output stays
+as the canonical file.  Either way, `/tmp/security-findings.json` is the
+single input to Phase 2.
 
 ## Phase 2: Triage and Close (parallel)
 

--- a/plugins/security-scanner/references/finding-severity-rubric.md
+++ b/plugins/security-scanner/references/finding-severity-rubric.md
@@ -30,6 +30,20 @@ These rules take precedence over tool-reported severity:
    file (`*.test.*`, `*.spec.*`, `__tests__/`), downgrade one severity level.
    A high becomes medium; a medium becomes low (and is not filed).
 
+## Supabase Findings
+
+Supabase findings use the same critical/high/medium/low scale.  Named-rule
+overrides (per rule_id) are the canonical source in `supabase-rule-catalog.md`
+— each catalog entry declares its severity.  Use those values.
+
+When an advisor `name` is not in the catalog, fall back by advisor `level`:
+
+| Advisor `level` | Severity |
+|---|---|
+| `ERROR` | high |
+| `WARN` | medium |
+| `INFO` | low (logged only) |
+
 ## Common False Positive Patterns
 
 These patterns frequently generate false positives.  Note them but do not

--- a/plugins/security-scanner/references/fingerprint-spec.md
+++ b/plugins/security-scanner/references/fingerprint-spec.md
@@ -54,9 +54,76 @@ The fingerprint is stored in the issue body as an HTML comment on the last line:
 
 This makes it machine-readable without being visible to humans viewing the issue.
 
+### For Supabase advisor findings (supabase-advisor)
+
+Canonical string:
+```
+supabase-advisor|<advisor_name>|<schema>.<entity>
+```
+
+Where:
+- `advisor_name`: the `name` field from the Supabase Management API advisor
+  response (e.g. `rls_disabled_in_public`)
+- `schema`: `metadata.schema` from the advisor response, or `public` if absent
+- `entity`: first non-empty of `metadata.table`, `metadata.function`,
+  `metadata.view`, `metadata.name`. For `auth_config`-level advisors (leaked
+  password protection, OTP expiry, MFA options) with no entity, use the literal
+  string `auth_config`.
+
+Example: `supabase-advisor|rls_disabled_in_public|public.profiles`
+Example: `supabase-advisor|auth_leaked_password_protection|auth_config`
+
+### For Supabase static schema findings (supabase-schema)
+
+Canonical string:
+```
+supabase-schema|<rule_id>|<file>|<line_band>
+```
+
+Same 10-line banding as other static analysis sources. `rule_id` is the static
+detector id (e.g. `missing_rls`, `policy_allows_all`).
+
+Example: `supabase-schema|missing_rls|supabase/migrations/20260410_add_profiles.sql|40`
+
+### For Supabase config findings (supabase-config)
+
+Canonical string:
+```
+supabase-config|<rule_id>|<config_key>
+```
+
+Where:
+- `rule_id`: the static detector id (e.g. `weak_password_policy`)
+- `config_key`: the TOML path of the offending setting
+  (e.g. `auth.minimum_password_length`)
+
+Example: `supabase-config|weak_password_policy|auth.minimum_password_length`
+
+## Supabase Cache Key (Separate from Fingerprint)
+
+Supabase advisor findings carry an additional `cache_key` returned by the
+Management API.  This is stored in the issue body as a sibling HTML comment,
+alongside (not replacing) the fingerprint:
+
+```
+<!-- fingerprint: <hex> -->
+<!-- supabase_cache_key: <key> -->
+```
+
+The cache key is used only for human cross-reference against the Supabase
+dashboard advisor list — it is not used for dedup or auto-close (the
+fingerprint does that).  For non-advisor findings the line is omitted or
+rendered as `<!-- supabase_cache_key: none -->`.
+
 ## Collision Policy
 
 Line-band collisions (two different findings in the same 10-line window of the
 same file from the same rule) are acceptable — they will be treated as the same
 finding.  In practice this is rare.  If it causes problems in a specific file,
 the suppression mechanism handles it.
+
+Note: the Supabase advisor and static paths may produce different fingerprints
+for the same underlying issue (e.g. RLS disabled on a table, seen both by the
+advisor API and by scanning the migration that created the table).  This is
+intentional — each finding files its own issue; fixing the underlying problem
+causes both to auto-close on the next scan.

--- a/plugins/security-scanner/references/issue-template.md
+++ b/plugins/security-scanner/references/issue-template.md
@@ -31,4 +31,9 @@ with the suppressed label — do not close it.  Add a comment explaining why it
 is a false positive.
 
 <!-- fingerprint: <hex> -->
+<!-- supabase_cache_key: <key or none> -->
 ```
+
+The `supabase_cache_key` comment is populated only for findings from the
+Supabase advisor API (`source: supabase-advisor`).  For all other findings it
+renders as `<!-- supabase_cache_key: none -->` and can be ignored.

--- a/plugins/security-scanner/references/supabase-audit-guide.md
+++ b/plugins/security-scanner/references/supabase-audit-guide.md
@@ -1,0 +1,223 @@
+# Supabase Audit Guide
+
+Reference for the `security-supabase-auditor` agent. Covers detection signals,
+project ref and token resolution, the Supabase Management API call, static
+parsing rules, and the output schema.
+
+## Detection
+
+The auditor only runs if Supabase is in use. Signals, checked in order — any
+one match is sufficient:
+
+1. `supabase/config.toml` exists at repo root.
+2. `@supabase/supabase-js` is listed in `package.json` `dependencies` or
+   `devDependencies`.
+3. `SUPABASE_URL` is set in any `.env*` file in the repo root.
+4. `supabase/migrations/` exists and contains at least one `.sql` file.
+
+No match → the auditor writes an empty findings file at
+`/tmp/security-findings-supabase.json` and logs:
+
+```
+Supabase not detected — skipping.
+```
+
+## Project ref resolution
+
+Tried in order. First match wins; log which source was used.
+
+1. `$SUPABASE_PROJECT_REF` environment variable.
+2. `project_id` field in `supabase/config.toml`.
+3. Parse `SUPABASE_URL` from `.env*` — the ref is the subdomain of
+   `https://<ref>.supabase.co`.
+
+If no ref resolves, skip the API path and run static-only. Log:
+
+```
+No Supabase project ref found — skipping advisor API, running static-only.
+```
+
+Do not fail the scan.
+
+## Access token resolution
+
+`$SUPABASE_ACCESS_TOKEN` is the only source. Generate one at
+https://supabase.com/dashboard/account/tokens.
+
+If unset, skip the API path. Log:
+
+```
+SUPABASE_ACCESS_TOKEN not set — skipping advisor API, running static-only.
+```
+
+Never echo the token value to terminal or into any file.
+
+## Advisor API call
+
+Single endpoint, GET, JSON response:
+
+```bash
+HTTP_STATUS=$(curl -sS -o /tmp/sec-supabase-advisors.json -w '%{http_code}' \
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+  "https://api.supabase.com/v1/projects/${PROJECT_REF}/advisors?type=security")
+```
+
+Only `type=security` is queried. Performance advisors are intentionally out of
+scope.
+
+### Response handling
+
+- **200**: Parse findings. Each finding has the fields listed below.
+- **401 / 403**: Token is invalid or missing scope. Log status + first 200
+  chars of body. Add `supabase-advisor-api` to `skipped_tools`. Fall back to
+  static-only.
+- **404**: Project ref is wrong. Log and fall back to static-only.
+- **5xx or timeout**: Supabase outage. Log and fall back to static-only.
+
+### Advisor response fields used by the auditor
+
+| Field | Use |
+|---|---|
+| `name` | becomes `rule_id` (e.g. `rls_disabled_in_public`) |
+| `title` | short description |
+| `level` | `ERROR` / `WARN` / `INFO` — mapped to severity per rubric |
+| `description` | `message` (combined with `detail` if present) |
+| `detail` | appended to `message` |
+| `remediation` | `recommendation` — URL to Supabase docs |
+| `metadata` | entity extraction; see below |
+| `cache_key` | stored in issue body as `<!-- supabase_cache_key: <key> -->` |
+
+### Entity extraction from `metadata`
+
+Advisor metadata is shaped differently per rule family. Entity name resolution
+tries these keys in order; first non-empty value wins:
+
+1. `metadata.table`
+2. `metadata.function`
+3. `metadata.view`
+4. `metadata.name`
+
+Fallback: `"(unknown)"`. Schema is always `metadata.schema` when present,
+otherwise `public`.
+
+The resulting entity identifier is `<schema>.<entity>` — used in both the
+fingerprint and the filed issue's `**File**:` analog line.
+
+For `auth_config`-level advisors with no entity (leaked-password protection,
+OTP expiry, MFA options), use the literal entity string `auth_config`.
+
+## Static path
+
+Runs unconditionally (independent of the API path — both paths contribute
+findings).
+
+### Migration scan
+
+Glob `supabase/migrations/*.sql`. Explicitly **exclude**:
+
+- `supabase/seed.sql` and anything matching `supabase/seed.*.sql`
+- Anything under `supabase/tests/**`
+
+Seed and test files routinely contain allow-all policies and fixture grants
+that are intentional for local dev — scanning them generates noise.
+
+Detectors (per `supabase-rule-catalog.md` for full rule text):
+
+| rule_id | pattern |
+|---|---|
+| `missing_rls` | `CREATE TABLE <name>` in `public` with no `ALTER TABLE <name> ENABLE ROW LEVEL SECURITY` later in the same file |
+| `policy_allows_all` | `CREATE POLICY` followed by `USING (true)` or `WITH CHECK (true)` |
+| `security_definer_no_search_path` | `CREATE FUNCTION ... SECURITY DEFINER` with no `SET search_path` clause before the `AS` body |
+| `grant_to_anon` | `GRANT <privs> ON ... TO anon` |
+| `view_references_auth_users` | `CREATE VIEW` or `CREATE OR REPLACE VIEW` whose body contains `auth.users` or `auth.identities` |
+
+All use case-insensitive regex. Record `file` (relative path), `line_start`,
+and `line_end` (the line of the first matching pattern through the end of the
+statement, approximate is fine — `line_band` handles minor drift).
+
+### Config scan
+
+Parse `supabase/config.toml` if present. Flag (see catalog for severity and
+fix text):
+
+| rule_id | condition |
+|---|---|
+| `weak_password_policy` | `[auth] minimum_password_length < 10` |
+| `signup_without_confirmation` | `[auth] enable_signup = true` and `[auth.email] enable_confirmations = false` |
+| `api_schemas_overexposed` | `[api] schemas` contains anything beyond `public`, `graphql_public`, `storage` |
+
+These findings reflect developer intent for local dev. Production auth config
+lives in the Supabase dashboard and comes through the advisor API — note this
+in the filed issue body so users don't assume a config.toml fix addresses
+production.
+
+## Output schema
+
+Write `/tmp/security-findings-supabase.json`:
+
+```json
+{
+  "scan_timestamp": "<ISO 8601>",
+  "mode": "<quick|full>",
+  "repo": "<OWNER/REPO>",
+  "skipped_tools": ["supabase-advisor-api"],
+  "findings": [
+    {
+      "fingerprint": "<sha256 hex>",
+      "source": "<supabase-advisor|supabase-schema|supabase-config>",
+      "rule_id": "<advisor name or static rule_id>",
+      "file": "<relative path or null>",
+      "line_start": 42,
+      "line_end": 45,
+      "severity": "<critical|high|medium|low>",
+      "title": "<short description>",
+      "message": "<description + detail>",
+      "recommendation": "<URL from advisor remediation or catalog fallback>",
+      "cache_key": "<advisor cache_key or null>",
+      "entity": "<schema.entity or null>"
+    }
+  ]
+}
+```
+
+Fields `cache_key` and `entity` are optional. All existing finding fields from
+`security-runner` output are reused unchanged.
+
+`skipped_tools` is only present when the advisor API was attempted and
+failed/unavailable. Empty array or missing if everything ran cleanly.
+
+## Fingerprints
+
+Three canonical strings — see `fingerprint-spec.md` for the full spec:
+
+- `supabase-advisor|<advisor_name>|<schema>.<entity>`
+- `supabase-schema|<rule_id>|<file>|<line_band>`
+- `supabase-config|<rule_id>|<config_key>`
+
+API and static paths may produce findings with different fingerprints for the
+same underlying issue (e.g. RLS disabled seen both by advisor and by migration
+scan). That is intentional — each gets its own issue; resolving the
+underlying problem causes both to auto-close on the next scan.
+
+## Summary output
+
+After completion, print:
+
+```
+## Supabase Auditor Summary
+
+Detection: <detected | not-detected>
+API path: <ok | skipped-no-token | skipped-no-ref | skipped-<HTTP status>>
+Static path: <ran | skipped>
+
+### Findings
+
+| Source | Critical | High | Medium | Low |
+|--------|----------|------|--------|-----|
+| supabase-advisor | X | X | X | X |
+| supabase-schema  | X | X | X | X |
+| supabase-config  | X | X | X | X |
+| **Total**        | X | X | X | X |
+```
+
+State: `Supabase findings written to /tmp/security-findings-supabase.json`.

--- a/plugins/security-scanner/references/supabase-rule-catalog.md
+++ b/plugins/security-scanner/references/supabase-rule-catalog.md
@@ -1,0 +1,212 @@
+# Supabase Rule Catalog
+
+Local catalog of Supabase security rules known to the auditor. Each entry
+provides a severity override, a remediation URL, and fallback remediation text
+used when the Supabase advisor API response has an empty `remediation` field.
+
+## How the auditor resolves remediation
+
+For each finding with `source: supabase-advisor`:
+
+1. If the advisor response includes a non-empty `remediation` URL, use it.
+2. Otherwise, look up the advisor `name` in this catalog and use the
+   `remediation_url` + `remediation_text` below.
+3. If neither the API nor this catalog has a match, the filed issue shows
+   `See Supabase Database Advisor docs for <rule_id>` as a neutral placeholder
+   and the unknown `name` is logged to terminal.
+
+Catalog entries are keyed by `rule_id` — that is, the advisor `name` field for
+API findings or the static detector id for `supabase-schema` / `supabase-config`
+findings. All severities here are the plugin's adjusted severity; the advisor
+`level` field is consulted only as a fallback when a rule is not in this
+catalog.
+
+## Catalog
+
+### Advisor rules (API source)
+
+#### `rls_disabled_in_public`
+- **severity**: critical
+- **remediation_url**: https://supabase.com/docs/guides/database/postgres/row-level-security
+- **remediation_text**: Enable Row Level Security on this table:
+  `ALTER TABLE <schema>.<table> ENABLE ROW LEVEL SECURITY;` and add policies
+  that restrict access to `auth.uid()` or a specific role. A table in the
+  `public` schema with RLS disabled is readable by anyone with the anon key.
+- **notes**: The single highest-impact misconfiguration. Any table reachable
+  through PostgREST / the client SDK must have RLS enabled.
+
+#### `policy_exists_rls_disabled`
+- **severity**: critical
+- **remediation_url**: https://supabase.com/docs/guides/database/postgres/row-level-security
+- **remediation_text**: Policies are defined on this table but RLS itself is
+  not enabled, so the policies have no effect. Run
+  `ALTER TABLE <schema>.<table> ENABLE ROW LEVEL SECURITY;`.
+- **notes**: Often indicates a developer intended to secure the table but
+  forgot the `ENABLE` statement.
+
+#### `rls_enabled_no_policy`
+- **severity**: medium
+- **remediation_url**: https://supabase.com/docs/guides/database/postgres/row-level-security
+- **remediation_text**: RLS is enabled on this table but no policies are
+  defined, so no role can read or write. Either add policies scoped to
+  `auth.uid()` / a role, or disable RLS if the table is intentionally empty of
+  client access.
+- **notes**: Symptom of incomplete migration. Medium because data is not
+  exposed — the table is simply unreachable.
+
+#### `security_definer_view`
+- **severity**: high
+- **remediation_url**: https://supabase.com/docs/guides/database/database-linter?lint=0010_security_definer_view
+- **remediation_text**: This view runs with the permissions of its owner
+  (typically `postgres`), bypassing the querying user's RLS. Recreate the view
+  with `security_invoker=true` or convert it to a function that pins
+  `search_path` and is `SECURITY INVOKER`.
+- **notes**: Classic RLS bypass pattern.
+
+#### `function_search_path_mutable`
+- **severity**: high
+- **remediation_url**: https://supabase.com/docs/guides/database/database-linter?lint=0011_function_search_path_mutable
+- **remediation_text**: Add `SET search_path = ''` (or an explicit schema list)
+  to the function definition. A `SECURITY DEFINER` function with a mutable
+  `search_path` is vulnerable to search-path hijacking — an attacker who can
+  create objects in any schema on the path can inject code that runs as the
+  function owner.
+- **notes**: Only applies to `SECURITY DEFINER` functions; `SECURITY INVOKER`
+  is unaffected.
+
+#### `auth_users_exposed`
+- **severity**: critical
+- **remediation_url**: https://supabase.com/docs/guides/database/database-linter?lint=0002_auth_users_exposed
+- **remediation_text**: A view or function in an API-exposed schema references
+  `auth.users`, leaking user identifiers, emails, and metadata to any
+  authenticated or anon client. Remove the `auth.users` reference or move the
+  view to a non-exposed schema.
+- **notes**: Email enumeration / user discovery vector.
+
+#### `extension_in_public`
+- **severity**: high
+- **remediation_url**: https://supabase.com/docs/guides/database/database-linter?lint=0014_extension_in_public
+- **remediation_text**: Move the extension to a dedicated schema (typically
+  `extensions`): `DROP EXTENSION <name>; CREATE EXTENSION <name> SCHEMA
+  extensions;`. Extensions in `public` pollute the namespace and can mask
+  functions via search-path manipulation.
+- **notes**: Usually safe to fix in a migration, but verify the extension's
+  functions aren't referenced unqualified elsewhere.
+
+#### `extension_versions_outdated`
+- **severity**: medium
+- **remediation_url**: https://supabase.com/docs/guides/database/extensions
+- **remediation_text**: Upgrade the extension to the latest available version:
+  `ALTER EXTENSION <name> UPDATE;`. Outdated extensions may ship with known
+  CVEs.
+
+#### `auth_leaked_password_protection`
+- **severity**: high
+- **remediation_url**: https://supabase.com/docs/guides/auth/password-security#password-strength-and-leaked-password-protection
+- **remediation_text**: Enable leaked-password protection in the Supabase
+  dashboard under Authentication → Providers → Email. When enabled, Supabase
+  checks new passwords against HaveIBeenPwned and rejects known-breached
+  passwords.
+- **notes**: No SQL fix — dashboard setting only.
+
+#### `auth_otp_long_expiry`
+- **severity**: medium
+- **remediation_url**: https://supabase.com/docs/guides/auth/auth-email-passwordless
+- **remediation_text**: Reduce OTP expiry to 3600 seconds (1 hour) or less in
+  Authentication → Providers → Email. Long-lived OTPs extend the window for
+  interception attacks.
+
+#### `auth_insufficient_mfa_options`
+- **severity**: medium
+- **remediation_url**: https://supabase.com/docs/guides/auth/auth-mfa
+- **remediation_text**: Enable at least one MFA factor (TOTP recommended) in
+  Authentication → Multi-Factor Authentication.
+
+#### `no_primary_key`
+- **severity**: low
+- **remediation_url**: https://supabase.com/docs/guides/database/database-linter?lint=0001_no_primary_key
+- **remediation_text**: Add a primary key to the table. Not a direct security
+  issue, but tables without primary keys break Supabase Realtime replication
+  and complicate auditing.
+- **notes**: Logged only; not filed as an issue (below medium threshold).
+
+### Static rules (migration source — `supabase-schema`)
+
+#### `missing_rls`
+- **severity**: critical
+- **remediation_url**: https://supabase.com/docs/guides/database/postgres/row-level-security
+- **remediation_text**: This migration creates a table in `public` without
+  enabling RLS. Append `ALTER TABLE <table> ENABLE ROW LEVEL SECURITY;` and
+  add policies before deploying.
+- **detector**: `CREATE TABLE` in schema `public` with no matching
+  `ENABLE ROW LEVEL SECURITY` in the same migration file.
+
+#### `policy_allows_all`
+- **severity**: critical
+- **remediation_url**: https://supabase.com/docs/guides/database/postgres/row-level-security#policies
+- **remediation_text**: A policy with `USING (true)` or `WITH CHECK (true)`
+  grants unconditional access. Scope it to `auth.uid() = user_id` or a role
+  check. If the table is intentionally world-readable, add a comment
+  documenting that and suppress the finding.
+- **detector**: `CREATE POLICY` followed by `USING (true)` or `WITH CHECK (true)`.
+
+#### `security_definer_no_search_path`
+- **severity**: high
+- **remediation_url**: https://supabase.com/docs/guides/database/database-linter?lint=0011_function_search_path_mutable
+- **remediation_text**: Append `SET search_path = ''` (or an explicit schema
+  list) to the function definition. Without this, the function is vulnerable
+  to search-path hijacking.
+- **detector**: `CREATE FUNCTION ... SECURITY DEFINER` with no
+  `SET search_path` clause in the same statement.
+
+#### `grant_to_anon`
+- **severity**: high
+- **remediation_url**: https://supabase.com/docs/guides/database/postgres/roles
+- **remediation_text**: `GRANT` statements targeting `anon` expose data to
+  unauthenticated clients. Replace with `authenticated` or revoke entirely
+  and use RLS policies instead.
+- **detector**: `GRANT ... TO anon` on a table.
+
+#### `view_references_auth_users`
+- **severity**: critical
+- **remediation_url**: https://supabase.com/docs/guides/database/database-linter?lint=0002_auth_users_exposed
+- **remediation_text**: Views in `public` or any API-exposed schema must not
+  reference `auth.users` or `auth.identities`. Remove the reference or move
+  the view to a non-exposed schema.
+- **detector**: `CREATE OR REPLACE VIEW` (or `CREATE VIEW`) with body
+  referencing `auth.users` / `auth.identities`.
+
+### Static rules (config.toml source — `supabase-config`)
+
+#### `weak_password_policy`
+- **severity**: medium
+- **remediation_url**: https://supabase.com/docs/guides/auth/password-security
+- **remediation_text**: Set `[auth] minimum_password_length = 12` (or higher)
+  in `supabase/config.toml`. The current value is below 10. Note: production
+  auth config lives in the Supabase dashboard — this finding reflects
+  developer intent for local environments.
+
+#### `signup_without_confirmation`
+- **severity**: medium
+- **remediation_url**: https://supabase.com/docs/guides/auth/auth-email
+- **remediation_text**: Either set `[auth.email] enable_confirmations = true`
+  or set `[auth] enable_signup = false`. Signup without email confirmation
+  allows account creation with arbitrary addresses.
+
+#### `api_schemas_overexposed`
+- **severity**: medium
+- **remediation_url**: https://supabase.com/docs/guides/api#api-schemas
+- **remediation_text**: Remove non-default schemas from `[api] schemas`. The
+  default exposed set is `["public", "graphql_public", "storage"]`; every
+  additional schema exposes its tables and functions to PostgREST.
+
+## Adding new rules
+
+New advisor rules show up over time as Supabase updates its linter. When the
+auditor encounters a rule not in this catalog:
+
+1. The finding is still filed (using the API-returned `remediation` if
+   present).
+2. The unknown rule name is logged to terminal.
+3. Add the rule to this catalog in a follow-up change so the severity and
+   fallback remediation are both captured for future scans.

--- a/plugins/security-scanner/references/tool-install-guide.md
+++ b/plugins/security-scanner/references/tool-install-guide.md
@@ -3,6 +3,23 @@
 The security-runner agent checks for and installs these tools before scanning.
 All tools are installed as dev dependencies or via npx — no global installs.
 
+## Orchestrator prerequisites
+
+### jq (required)
+
+The orchestrator merges findings from `security-runner` and
+`security-supabase-auditor` using `jq`.  It is a hard prerequisite — the
+command fails in its prerequisites step if `jq` is not on PATH.
+
+```bash
+command -v jq
+```
+
+If missing:
+- macOS: `brew install jq`
+- Debian/Ubuntu: `sudo apt-get install jq`
+- RHEL/Fedora: `sudo dnf install jq`
+
 ## Required for quick mode
 
 ### npm audit
@@ -41,6 +58,35 @@ semgrep rule configs are fetched at runtime from the semgrep registry.  They
 require internet access.  If the scan environment is air-gapped, these configs
 must be pre-downloaded and referenced by local path.  This is out of scope for
 v0.1 — flag it if the environment has no outbound internet.
+
+## Supabase auditing (optional)
+
+The `security-supabase-auditor` agent runs alongside `security-runner` when a
+Supabase project is detected.  It has two data sources:
+
+### Advisor API (preferred)
+
+Calls `https://api.supabase.com/v1/projects/{ref}/advisors?type=security` via
+`curl`.  Requires:
+
+- `SUPABASE_ACCESS_TOKEN` environment variable.  Create a personal access
+  token at https://supabase.com/dashboard/account/tokens and export it in
+  the shell that runs the scanner.
+- A resolvable project ref.  The auditor tries in order:
+  `$SUPABASE_PROJECT_REF`, `project_id` in `supabase/config.toml`, and the
+  subdomain of `SUPABASE_URL` from any `.env*` file.
+
+No additional tools are installed — `curl` is standard on macOS and Linux.
+
+If the token or project ref is missing, or the API returns a non-200
+response, the auditor logs the issue and falls back to static-only.  The
+scan does not fail.
+
+### Static fallback
+
+Parses `supabase/migrations/*.sql` and `supabase/config.toml` locally.
+Requires no external dependencies.  See `supabase-audit-guide.md` for the
+full rule set.
 
 ## Tool Failure Handling
 


### PR DESCRIPTION
## Summary

- Adds `security-supabase-auditor` agent that runs in parallel with `security-runner`, covering RLS misconfiguration, `SECURITY DEFINER` hygiene, `auth.users` exposure, auth hardening (leaked-password protection, MFA, OTP expiry, weak passwords), and API schema overexposure
- Uses Supabase Management API (`/v1/projects/{ref}/advisors?type=security`) via `curl` + `SUPABASE_ACCESS_TOKEN` — portable, no MCP dependency; falls back to static scanning of `supabase/migrations/*.sql` and `supabase/config.toml`
- Advisor findings carry Supabase's official remediation URL in the filed issue's Recommendation section; `supabase-rule-catalog.md` provides fallback for empty `remediation` fields
- `jq` added as hard prerequisite; findings merged before the existing triager/closer pipeline (both agents unchanged)

## Test plan

- [ ] Run `/security-scanner owner/repo quick` in a Supabase repo without `SUPABASE_ACCESS_TOKEN` — confirm static-only path, migration RLS findings filed
- [ ] Export `SUPABASE_ACCESS_TOKEN` and re-run — confirm advisor findings filed with remediation URLs and `supabase_cache_key` comment
- [ ] Run in a non-Supabase repo — confirm auditor logs "not detected" and pipeline completes cleanly
- [ ] Re-run against same state — confirm new issues = 0, duplicates skipped
- [ ] Fix a planted finding and re-run — confirm auto-close
- [ ] Verify `jq -r .version plugins/security-scanner/.claude-plugin/plugin.json` == `0.2.0` and matches marketplace.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)