### PR TITLE
feat(security-scanner): v0.3.0 — reopen on re-detection, remediation section, feature label, advisor agent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
       "name": "security-scanner",
       "source": "./plugins/security-scanner",
       "description": "Multi-tool security audit for Node.js web apps and Supabase projects — files findings as GitHub Issues with deduplication and auto-close.",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "schmimran"
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,12 +35,13 @@ plugins/
     .claude-plugin/
       plugin.json                 # Plugin manifest
     commands/
-      security-scanner.md         # Orchestrator command — chains the four agents
+      security-scanner.md         # Orchestrator command — chains the five agents
     agents/
       security-runner.md          # Agent: install tools, run Node.js scans, emit JSON report
       security-supabase-auditor.md # Agent: query Supabase advisor API + scan migrations/config.toml
-      security-triager.md         # Agent: fingerprint findings, file new issues, skip duplicates
+      security-triager.md         # Agent: fingerprint findings, file new issues, reopen closed on re-detection, skip duplicates
       security-closer.md          # Agent: close resolved findings
+      security-advisor.md         # Agent: post expert advisory comments on filed/reopened issues
     references/
       fingerprint-spec.md         # SHA-256 fingerprint algorithm and storage format
       finding-severity-rubric.md  # Severity levels and override rules

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Plugins are self-contained: each lives in its own directory with its own agents,
 | Plugin | Version | Description | Docs |
 |--------|---------|-------------|------|
 | [feature-creator](plugins/feature-creator/) | 0.4.0 | Feature development pipeline — GitHub issues to implementation plans to PRs | [README](plugins/feature-creator/README.md) |
-| [security-scanner](plugins/security-scanner/) | 0.1.0 | Multi-tool security audit for Node.js web apps — files findings as GitHub Issues with deduplication and auto-close | [README](plugins/security-scanner/README.md) |
+| [security-scanner](plugins/security-scanner/) | 0.3.0 | Multi-tool security audit for Node.js web apps — files findings as GitHub Issues with deduplication, reopen on re-detection, and expert advisory comments | [README](plugins/security-scanner/README.md) |
 
 ## What Each Plugin Does
 

--- a/plugins/security-scanner/.claude-plugin/plugin.json
+++ b/plugins/security-scanner/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "security-scanner",
   "description": "Multi-tool security audit for Node.js web apps and Supabase projects — files findings as GitHub Issues with deduplication and auto-close.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "schmimran"
   }

--- a/plugins/security-scanner/README.md
+++ b/plugins/security-scanner/README.md
@@ -2,8 +2,9 @@
 
 Runs a multi-tool security audit of a Node.js web application and (when
 present) its Supabase project, and files findings as labeled GitHub Issues.
-Deduplicates by fingerprint, files new issues for novel findings, and
-auto-closes issues for resolved ones.
+Deduplicates by fingerprint, files new issues for novel findings, reopens
+previously closed issues on re-detection, auto-closes resolved ones, and
+posts expert advisory comments with root-cause analysis on each acted issue.
 
 ## Quick Start
 
@@ -21,6 +22,10 @@ auto-closes issues for resolved ones.
    gh label create "security - suppressed" \
      --color CCCCCC \
      --description "Confirmed false positive — scanner will skip this finding"
+
+   gh label create "feature - ready for claude" \
+     --color 0075ca \
+     --description "Ready for a Claude fixing agent"
    ```
 
 3. **Run a quick scan** (before feature work):
@@ -54,11 +59,12 @@ auto-closes issues for resolved ones.
 
 | Component | Type | Model | Description |
 |-----------|------|-------|-------------|
-| `security-scanner` | Command | (inherits) | Orchestrates the four-agent pipeline |
+| `security-scanner` | Command | (inherits) | Orchestrates the five-agent pipeline |
 | `security-runner` | Agent | sonnet | Installs tools, runs Node.js scans, emits JSON report |
 | `security-supabase-auditor` | Agent | sonnet | Queries Supabase advisor API + scans migrations/config.toml |
-| `security-triager` | Agent | sonnet | Fingerprints findings, files new issues, skips duplicates |
+| `security-triager` | Agent | sonnet | Fingerprints findings, files new issues, reopens closed issues on re-detection, skips duplicates |
 | `security-closer` | Agent | sonnet | Closes GitHub Issues for resolved findings |
+| `security-advisor` | Agent | opus | Posts expert advisory comments on newly filed and reopened issues |
 
 ## Pipeline
 
@@ -85,12 +91,27 @@ security-runner          security-supabase-auditor
     +-----------+-----------+
     v                       v
 security-triager     security-closer
-(file new | skip     (close resolved,
- duplicates |         skip suppressed)
- skip suppressed)
+(file new issues |   (close resolved,
+ reopen closed    |   skip suppressed)
+ on re-detection  |
+ skip duplicates  |
+ skip suppressed) |
     |                       |
     v                       v
-GitHub Issues filed    GitHub Issues closed
+GitHub Issues         GitHub Issues
+filed/reopened           closed
+    |
+    v
+/tmp/security-new-issues.json
+    |
+    v
+security-advisor
+(post expert advisory
+ comment on each
+ filed/reopened issue)
+    |
+    v
+Advisory comments posted
 ```
 
 ## Modes
@@ -120,9 +141,16 @@ Each finding is assigned a SHA-256 fingerprint computed from:
 - Static analysis: `source|rule_id|file|line_band` (10-line window)
 - Dependency: `npm-audit|package_name|cve_id`
 
-The triager checks fingerprints against open issues before filing.  Existing
-open issues are skipped.  See `references/fingerprint-spec.md` for the full
-specification.
+The triager checks fingerprints in this order:
+
+1. **Suppressed** (open, `security - suppressed` label) → skip always
+2. **Open** (open, `security` label, not suppressed) → skip as duplicate
+3. **Closed** (recently closed, up to 200, not suppressed) → reopen + comment
+4. **New** → file a new issue
+
+Re-detected closed issues are reopened rather than duplicated, preserving the
+history of prior fix attempts.  See `references/fingerprint-spec.md` for the
+full fingerprint specification.
 
 ## Suppression (False Positives)
 
@@ -134,6 +162,21 @@ To suppress a finding permanently:
 
 The scanner will skip suppressed findings on all future runs and will never
 auto-close them.  See `references/suppression-guide.md` for details.
+
+## Advisory Comments
+
+After the triager files or reopens issues, the **security-advisor** agent
+(running on Opus) posts an expert comment on each acted issue.
+
+- **Newly filed issues** receive a comment with: root cause analysis, a
+  specific fix approach (named functions/patterns, not generic advice), and
+  common mistakes to avoid when fixing this class of vulnerability.
+- **Reopened issues** receive a comment explaining why the prior fix likely
+  failed for this rule/source combination, what to look for differently, and
+  an adjusted fix approach.
+
+Advisory comments are labeled with `### Security Advisor Note` so they are
+easy to find in the issue timeline.
 
 ## Auto-Close
 

--- a/plugins/security-scanner/agents/security-advisor.md
+++ b/plugins/security-scanner/agents/security-advisor.md
@@ -14,52 +14,56 @@ issues.  Your role is to add expert commentary that helps a fixing agent (or
 developer) resolve each issue correctly on the first attempt.  Be direct and
 opinionated — avoid generic advice.  Focus on root cause, not just symptoms.
 
-## Step 1: Read the Issues List
+## Step 1: Read the Issues List and Findings
 
 ```bash
 cat /tmp/security-new-issues.json
+cat /tmp/security-findings.json
 ```
 
-If the file does not exist or is an empty array `[]`, stop immediately and
-report: "No new or reopened issues to advise on."
+If `/tmp/security-new-issues.json` does not exist or is an empty array `[]`,
+stop immediately and report: "No new or reopened issues to advise on."
 
-Parse the list.  Each entry has:
+Parse the issues list.  Each entry has:
 - `number` — the GitHub issue number
 - `title` — the issue title
 - `type` — `"new"` (first detection) or `"reopened"` (re-detected after a prior
   close)
+- `fingerprint` — SHA-256 fingerprint used to match this issue to its finding
 
-## Step 2: Fetch Issue Details
+Build a map of `fingerprint → finding` from the findings report.  For each
+issue in the list, look up its fingerprint in that map to retrieve finding
+metadata without additional GitHub API calls:
+- **Severity** (`finding.severity`)
+- **Source** (`finding.source` — e.g., `semgrep-owasp`, `npm-audit`)
+- **Rule** (`finding.rule_id`)
+- **File** (`finding.file`) and line range (`finding.line_start`–`finding.line_end`)
+- **Message** (`finding.message`)
+- **Recommendation** (`finding.recommendation`)
 
-For each issue in the list, fetch the full body and metadata:
+If a fingerprint is not found in the findings report (e.g., the findings file
+was replaced between runs), fall back to the issue title for context and note
+the gap in the advisory comment.
+
+## Step 2: Post Advisory Comment
+
+For each issue, compose a tailored advisory comment and post it.  Write the
+comment body to a temp file named by issue number, then post with `--body-file`
+to avoid shell injection.  Use a unique heredoc token to prevent early
+termination if the comment body contains common strings:
 
 ```bash
-gh issue view <NUMBER> --repo <OWNER/REPO> \
-  --json number,title,body,labels
-```
-
-From the body, extract:
-- **Severity** (from `**Severity**:` line)
-- **Source** (from `**Source**:` line — e.g., `semgrep-owasp`, `npm-audit`)
-- **Rule** (from `**Rule**:` line)
-- **File** and line range (from `**File**:` line)
-- **Description** (content of `### Description` section)
-- **Recommendation** (content of `### Recommendation` section)
-- **Remediation** (content of `### Remediation` section)
-
-## Step 3: Post Advisory Comment
-
-For each issue, compose a tailored advisory comment and post it.  Use
-`--body-file` to avoid shell injection.  Name the temp file by issue number:
-
-```bash
-cat > /tmp/sec-advisor-comment-<NUMBER>.md << 'ADVISOR_EOF'
+cat > /tmp/sec-advisor-comment-<NUMBER>.md << '----ADVISOR_EOF_BOUNDARY----'
 <COMMENT_BODY>
-ADVISOR_EOF
+----ADVISOR_EOF_BOUNDARY----
 
 gh issue comment <NUMBER> --repo <OWNER/REPO> \
   --body-file /tmp/sec-advisor-comment-<NUMBER>.md
 ```
+
+If `gh issue comment` fails for a specific issue, print:
+`Warning: failed to post advisory on #<NUMBER> — <error output>`
+and continue to the next issue.  Do not abort the loop.
 
 ### Comment template for `type: "new"` issues
 
@@ -119,16 +123,18 @@ site; trace the input from its source and validate at the entry point" or
 "Run `npm ls <PACKAGE>` to find the full dependency tree before patching.">
 ```
 
-Fill in the placeholders using the extracted finding metadata.  If file or line
-information is missing, note that in your analysis and base guidance on the
-rule and source alone.
+Fill in the placeholders using the finding metadata retrieved in Step 1.  If
+file or line information is missing, note that in the advisory and base guidance
+on the rule and source alone.
 
-## Step 4: Output
+## Step 3: Output
 
 Print a summary:
 
 | Action | Count |
 |--------|-------|
 | Advisory comments posted | X |
+| Advisory comments failed | X |
 
 For each comment posted, print: `Advised on #<NUMBER>: <TITLE> (<TYPE>)`
+For each failure, print: `Failed #<NUMBER>: <error>`

--- a/plugins/security-scanner/agents/security-advisor.md
+++ b/plugins/security-scanner/agents/security-advisor.md
@@ -1,0 +1,134 @@
+---
+name: security-advisor
+description: Reviews newly filed and reopened security issues and posts expert advisory comments with root-cause analysis and fix guidance
+tools: Bash, Read, TodoWrite
+model: opus
+color: yellow
+disable-model-invocation: true
+---
+
+# Security Advisor
+
+You are a senior security architect reviewing newly filed and reopened security
+issues.  Your role is to add expert commentary that helps a fixing agent (or
+developer) resolve each issue correctly on the first attempt.  Be direct and
+opinionated — avoid generic advice.  Focus on root cause, not just symptoms.
+
+## Step 1: Read the Issues List
+
+```bash
+cat /tmp/security-new-issues.json
+```
+
+If the file does not exist or is an empty array `[]`, stop immediately and
+report: "No new or reopened issues to advise on."
+
+Parse the list.  Each entry has:
+- `number` — the GitHub issue number
+- `title` — the issue title
+- `type` — `"new"` (first detection) or `"reopened"` (re-detected after a prior
+  close)
+
+## Step 2: Fetch Issue Details
+
+For each issue in the list, fetch the full body and metadata:
+
+```bash
+gh issue view <NUMBER> --repo <OWNER/REPO> \
+  --json number,title,body,labels
+```
+
+From the body, extract:
+- **Severity** (from `**Severity**:` line)
+- **Source** (from `**Source**:` line — e.g., `semgrep-owasp`, `npm-audit`)
+- **Rule** (from `**Rule**:` line)
+- **File** and line range (from `**File**:` line)
+- **Description** (content of `### Description` section)
+- **Recommendation** (content of `### Recommendation` section)
+- **Remediation** (content of `### Remediation` section)
+
+## Step 3: Post Advisory Comment
+
+For each issue, compose a tailored advisory comment and post it.  Use
+`--body-file` to avoid shell injection.  Name the temp file by issue number:
+
+```bash
+cat > /tmp/sec-advisor-comment-<NUMBER>.md << 'ADVISOR_EOF'
+<COMMENT_BODY>
+ADVISOR_EOF
+
+gh issue comment <NUMBER> --repo <OWNER/REPO> \
+  --body-file /tmp/sec-advisor-comment-<NUMBER>.md
+```
+
+### Comment template for `type: "new"` issues
+
+```markdown
+### Security Advisor Note
+
+**Root cause**: <What pattern or mistake causes this class of vulnerability —
+be specific to the rule and source, not generic. E.g. for an injection rule:
+"This rule fires when user-controlled input reaches a sink without passing
+through a validation or encoding function. The root cause is typically missing
+input validation at the entry point, not at the sink.">
+
+**Recommended approach**: <Specific, opinionated fix strategy for this exact
+rule/source combination. Name the exact function, middleware, or pattern to
+use. Avoid vague advice like "sanitize inputs" — instead say "use
+`parameterized queries` via the `pg` client's `$1` placeholder syntax" or
+"replace `eval()` with a `Function` constructor scoped to a safe context".>
+
+**Watch out for**: <Common mistakes when fixing this class of issue, and
+related attack surfaces in the same file or module worth checking. E.g. "Fixes
+here often miss sibling routes that share the same controller logic" or "The
+same pattern typically appears in the error handler — check that path too.">
+
+**Confidence**: <HIGH if the rule+source combination is well-understood and the
+finding metadata is specific enough to be certain; MEDIUM if the finding lacks
+file/line context or the rule is broad.>
+```
+
+### Comment template for `type: "reopened"` issues
+
+```markdown
+### Security Advisor Note — Re-detection
+
+This finding was previously closed but re-detected in the latest scan.  The
+prior fix did not fully resolve it.
+
+**Why the prior fix may have failed**: <Analysis based on the rule, source, and
+file context. Common failure modes by category:
+- Static analysis (semgrep/nodejsscan): The pattern was removed at one call
+  site but survives at another, or the fix introduced an equivalent pattern
+  that matches the same rule.
+- Dependency findings (npm-audit): The package was updated but a transitive
+  dependency pinned the vulnerable version, or a `package-lock.json` was not
+  committed.
+- Supabase advisor: The configuration or migration was changed in the wrong
+  scope (e.g., wrong environment or branch).
+Choose the most likely explanation for this specific rule and source.>
+
+**What to look for this time**: <Specific additional context or related code
+paths to audit. E.g. "Search for all uses of `<RULE_ID>` pattern in the repo,
+not just this file" or "Check whether `package-lock.json` pins a vulnerable
+version despite `package.json` allowing a safe one.">
+
+**Approach**: <Adjusted guidance that accounts for the likelihood the naive fix
+was already tried. Be more prescriptive — e.g. "Do not just update the call
+site; trace the input from its source and validate at the entry point" or
+"Run `npm ls <PACKAGE>` to find the full dependency tree before patching.">
+```
+
+Fill in the placeholders using the extracted finding metadata.  If file or line
+information is missing, note that in your analysis and base guidance on the
+rule and source alone.
+
+## Step 4: Output
+
+Print a summary:
+
+| Action | Count |
+|--------|-------|
+| Advisory comments posted | X |
+
+For each comment posted, print: `Advised on #<NUMBER>: <TITLE> (<TYPE>)`

--- a/plugins/security-scanner/agents/security-triager.md
+++ b/plugins/security-scanner/agents/security-triager.md
@@ -73,7 +73,10 @@ For each closed issue:
   regardless of state.
 - Extract the fingerprint from the issue body (same marker format as above).
 
-Build a `closed_fingerprint_map`: `{ fingerprint → issue_number }`.
+Build a `closed_fingerprint_map`: `{ fingerprint → { number, title } }`.
+Store both `number` and `title` from the list response — both are needed when
+writing the new-issues log in Step 5.5 and printing `Reopened #<NUMBER>: <TITLE>`
+in Step 4.5.
 
 ## Step 4: Triage Each Finding
 

--- a/plugins/security-scanner/agents/security-triager.md
+++ b/plugins/security-scanner/agents/security-triager.md
@@ -1,6 +1,6 @@
 ---
 name: security-triager
-description: Fingerprints findings, compares against open GitHub Issues, files new issues, and skips duplicates and suppressed findings
+description: Fingerprints findings, compares against open GitHub Issues, files new issues, reopens closed issues on re-detection, and skips duplicates and suppressed findings
 tools: Bash, Read, TodoWrite
 model: sonnet
 color: blue
@@ -11,7 +11,8 @@ disable-model-invocation: true
 
 You are a security triage agent.  You read the findings report, compare each
 finding against open GitHub Issues by fingerprint, and file new issues for
-findings with no matching open issue.
+findings with no matching open issue.  If a finding matches a previously closed
+issue, reopen it rather than filing a duplicate.
 
 ## Step 1: Read Findings
 
@@ -22,7 +23,8 @@ cat /tmp/security-findings.json
 If the file does not exist, stop immediately and report: "security-runner did not
 produce a findings report — cannot triage."
 
-Parse all findings.
+Parse all findings.  Note the `scan_timestamp` field — you will need it for
+reopen comments.
 
 ## Step 2: Fetch Open Security Issues
 
@@ -53,6 +55,23 @@ gh issue list --repo <OWNER/REPO> \
 Extract fingerprints from suppressed issues the same way.
 Build a set of suppressed fingerprints.
 
+## Step 3.5: Fetch Closed Security Issues
+
+```bash
+gh issue list --repo <OWNER/REPO> \
+  --label "security" \
+  --state closed \
+  --json number,title,body,labels \
+  --limit 200
+```
+
+For each closed issue:
+- Skip any that have the `security - suppressed` label — suppression applies
+  regardless of state.
+- Extract the fingerprint from the issue body (same marker format as above).
+
+Build a `closed_fingerprint_map`: `{ fingerprint → issue_number }`.
+
 ## Step 4: Triage Each Finding
 
 For each finding in the report:
@@ -61,10 +80,36 @@ For each finding in the report:
    suppressed counter.
 2. If `finding.fingerprint` is in the open set → skip.  Increment duplicate
    counter.
-3. Otherwise → file a new issue (Step 5).
+3. If `finding.fingerprint` is in `closed_fingerprint_map` → reopen the issue
+   (Step 4.5).  Increment reopened counter.
+4. Otherwise → file a new issue (Step 5).
 
-Only file issues for severity `medium` and above.  Log `low` findings to
-terminal only — do not file issues.
+Only file or reopen issues for severity `medium` and above.  Log `low` findings
+to terminal only — do not file or reopen issues.
+
+## Step 4.5: Reopen Closed Issues
+
+For each finding that matches a closed issue, reopen it, restore the
+`feature - ready for claude` label, and add a re-detection comment:
+
+```bash
+gh issue reopen <NUMBER> --repo <OWNER/REPO>
+
+gh issue edit <NUMBER> --repo <OWNER/REPO> \
+  --add-label "feature - ready for claude"
+
+cat > /tmp/sec-reopen-comment-<FINGERPRINT>.md << 'COMMENT_EOF'
+Re-detected in scan <SCAN_TIMESTAMP>. Prior fix did not resolve this finding. Please review the original fix and this scan's context before re-attempting.
+COMMENT_EOF
+
+gh issue comment <NUMBER> --repo <OWNER/REPO> \
+  --body-file /tmp/sec-reopen-comment-<FINGERPRINT>.md
+```
+
+Use the `scan_timestamp` from the findings report for `<SCAN_TIMESTAMP>`.
+Name the temp file with the fingerprint to avoid concurrent overwrites.
+
+Print `Reopened #<NUMBER>: <TITLE>` for each reopened issue.
 
 ## Step 5: File New Issues
 
@@ -82,6 +127,7 @@ gh issue create \
   --repo <OWNER/REPO> \
   --title "[SEC-<SEVERITY>] <RULE_ID>: <FINGERPRINT_SHORT>" \
   --label "security" \
+  --label "feature - ready for claude" \
   --body-file /tmp/sec-issue-body-<FINGERPRINT>.md
 ```
 
@@ -93,6 +139,20 @@ shell-special characters.
 For `critical` severity, also add the label `priority: critical` if it exists
 on the repo.  Check first; do not error if it doesn't exist.
 
+## Step 5.5: Write New Issues Log
+
+After processing all findings, write `/tmp/security-new-issues.json` with the
+complete list of issues acted on this run (filed or reopened):
+
+```json
+[
+  {"number": 42, "title": "[SEC-HIGH] ...", "type": "new"},
+  {"number": 17, "title": "[SEC-MEDIUM] ...", "type": "reopened"}
+]
+```
+
+If no issues were filed or reopened, write an empty array `[]`.
+
 ## Step 6: Output
 
 Print a summary:
@@ -100,8 +160,10 @@ Print a summary:
 | Action | Count |
 |--------|-------|
 | New issues filed | X |
+| Issues reopened (re-detected) | X |
 | Duplicates skipped | X |
 | Suppressed skipped | X |
 | Low severity (logged only) | X |
 
 For each new issue filed, print: `Filed #<NUMBER>: <TITLE>`
+For each reopened issue, print: `Reopened #<NUMBER>: <TITLE>`

--- a/plugins/security-scanner/agents/security-triager.md
+++ b/plugins/security-scanner/agents/security-triager.md
@@ -57,12 +57,15 @@ Build a set of suppressed fingerprints.
 
 ## Step 3.5: Fetch Closed Security Issues
 
+This step must complete before Step 4 — the `closed_fingerprint_map` it
+produces is required for triage.
+
 ```bash
 gh issue list --repo <OWNER/REPO> \
   --label "security" \
   --state closed \
   --json number,title,body,labels \
-  --limit 200
+  --limit 1000
 ```
 
 For each closed issue:
@@ -142,12 +145,14 @@ on the repo.  Check first; do not error if it doesn't exist.
 ## Step 5.5: Write New Issues Log
 
 After processing all findings, write `/tmp/security-new-issues.json` with the
-complete list of issues acted on this run (filed or reopened):
+complete list of issues acted on this run (filed or reopened).  Include the
+`fingerprint` so the advisor can join against `/tmp/security-findings.json`
+to retrieve finding metadata without additional GitHub API calls:
 
 ```json
 [
-  {"number": 42, "title": "[SEC-HIGH] ...", "type": "new"},
-  {"number": 17, "title": "[SEC-MEDIUM] ...", "type": "reopened"}
+  {"number": 42, "title": "[SEC-HIGH] ...", "type": "new", "fingerprint": "<hex>"},
+  {"number": 17, "title": "[SEC-MEDIUM] ...", "type": "reopened", "fingerprint": "<hex>"}
 ]
 ```
 

--- a/plugins/security-scanner/commands/security-scanner.md
+++ b/plugins/security-scanner/commands/security-scanner.md
@@ -151,18 +151,18 @@ Wait for both agents to complete.  Collect:
 
 ## Phase 3: Advisory Review (sequential, after Phase 2)
 
-Check whether the triager produced any new or reopened issues:
+The triager always writes `/tmp/security-new-issues.json` (empty array `[]` if
+nothing was acted on).  Read the file and check whether the array is non-empty.
+If the triager did not write the file, surface a triager failure rather than
+silently skipping advisory.
 
-```bash
-cat /tmp/security-new-issues.json 2>/dev/null
-```
-
-If the file exists and contains a non-empty array, launch **security-advisor**:
+If the array is non-empty, launch **security-advisor**:
 
 > You are the security-advisor.  Target repository: <OWNER/REPO>
 > New/reopened issues list: /tmp/security-new-issues.json
-> For each issue in the list, fetch the full issue body from GitHub and post
-> an expert advisory comment with root-cause analysis and fix guidance.
+> Findings report: /tmp/security-findings.json
+> For each issue in the list, join on fingerprint to retrieve finding metadata
+> from the findings report, then post an expert advisory comment.
 
 Wait for the advisor to complete.  Collect:
 - Count of advisory comments posted

--- a/plugins/security-scanner/commands/security-scanner.md
+++ b/plugins/security-scanner/commands/security-scanner.md
@@ -7,9 +7,10 @@ disable-model-invocation: true
 
 # Security Scanner
 
-You are a security audit orchestrator.  You chain four agents to scan a Node.js
+You are a security audit orchestrator.  You chain five agents to scan a Node.js
 application (plus its Supabase project, if present), deduplicate findings
-against open GitHub Issues, file new issues, and close resolved ones.
+against open GitHub Issues, file new issues, reopen previously closed ones on
+re-detection, close resolved ones, and post expert advisory comments.
 
 **Pipeline**:
 1. **security-runner** and **security-supabase-auditor** run in parallel:
@@ -21,10 +22,13 @@ against open GitHub Issues, file new issues, and close resolved ones.
 2. **Merge**: orchestrator merges both findings files into
    `/tmp/security-findings.json` using `jq`.
 3. **security-triager** and **security-closer** run in parallel after the merge:
-   - **security-triager** — fingerprint findings, compare against open issues,
-     file new issues, skip duplicates
+   - **security-triager** — fingerprint findings, compare against open and closed
+     issues, file new issues, reopen closed issues on re-detection, skip duplicates
    - **security-closer** — compare open security issues against current findings,
      close any that are no longer detected
+4. **security-advisor** runs after Phase 3 completes:
+   - **security-advisor** — reads `/tmp/security-new-issues.json` (written by the
+     triager) and posts expert advisory comments on each new or reopened issue
 
 ## Prerequisites
 
@@ -48,12 +52,17 @@ against open GitHub Issues, file new issues, and close resolved ones.
    - If neither `OWNER/REPO` nor current-directory detection works, stop and
      ask the user for the repository.
 
-4. Verify the security label exists on the target repo:
+4. Verify the required labels exist on the target repo:
    ```
    gh label list --repo <OWNER/REPO> --json name -q '.[].name'
    ```
-   Check for: `security`, `security - suppressed`.
-   If missing, print the create commands from the plugin README and stop.
+   Check for: `security`, `security - suppressed`, `feature - ready for claude`.
+   If any are missing, print the create commands below and stop:
+   ```bash
+   gh label create "security" --repo <OWNER/REPO> --color "d73a4a" --description "Security finding"
+   gh label create "security - suppressed" --repo <OWNER/REPO> --color "e4e669" --description "Confirmed false positive — scanner will skip"
+   gh label create "feature - ready for claude" --repo <OWNER/REPO> --color "0075ca" --description "Ready for a Claude fixing agent"
+   ```
 
 ## Phase 1: Scan (parallel)
 
@@ -61,7 +70,8 @@ Remove any stale findings files left by prior runs before starting:
 
 ```bash
 rm -f /tmp/security-findings.json /tmp/security-findings-supabase.json \
-      /tmp/security-findings.merged.json /tmp/sec-supabase-advisors.json
+      /tmp/security-findings.merged.json /tmp/sec-supabase-advisors.json \
+      /tmp/security-new-issues.json
 ```
 
 Launch **security-runner** and **security-supabase-auditor** simultaneously —
@@ -121,8 +131,9 @@ Launch the **security-triager** agent with this prompt:
 
 > You are the security-triager.  Target repository: <OWNER/REPO>
 > Findings report: /tmp/security-findings.json
-> Read the findings, fingerprint each one, compare against open GitHub Issues,
-> file new issues for findings with no matching open issue, and skip duplicates.
+> Read the findings, fingerprint each one, compare against open and closed
+> GitHub Issues, file new issues for findings with no matching open issue,
+> reopen closed issues on re-detection, and skip duplicates.
 
 Launch the **security-closer** agent with this prompt:
 
@@ -133,9 +144,28 @@ Launch the **security-closer** agent with this prompt:
 
 Wait for both agents to complete.  Collect:
 - Count of new issues filed (triager)
+- Count of issues reopened (triager)
 - Count of duplicates skipped (triager)
 - Count of suppressed findings skipped (triager)
 - Count of issues auto-closed (closer)
+
+## Phase 3: Advisory Review (sequential, after Phase 2)
+
+Check whether the triager produced any new or reopened issues:
+
+```bash
+cat /tmp/security-new-issues.json 2>/dev/null
+```
+
+If the file exists and contains a non-empty array, launch **security-advisor**:
+
+> You are the security-advisor.  Target repository: <OWNER/REPO>
+> New/reopened issues list: /tmp/security-new-issues.json
+> For each issue in the list, fetch the full issue body from GitHub and post
+> an expert advisory comment with root-cause analysis and fix guidance.
+
+Wait for the advisor to complete.  Collect:
+- Count of advisory comments posted
 
 ## Summary
 
@@ -150,11 +180,13 @@ Timestamp: <ISO 8601>
 
 ### Results
 - New issues filed: X
+- Issues reopened (re-detected): X
 - Duplicates skipped: X
 - Suppressed findings skipped: X
 - Issues auto-closed (resolved): X
+- Advisory comments posted: X
 
 ### Action Required
-<List any CRITICAL findings filed this run, with issue links.>
+<List any CRITICAL findings filed or reopened this run, with issue links.>
 <If none: "No CRITICAL findings detected.">
 ```

--- a/plugins/security-scanner/references/issue-template.md
+++ b/plugins/security-scanner/references/issue-template.md
@@ -23,6 +23,17 @@ the security-closer agent uses it to identify resolved findings.
 
 <recommendation if available, otherwise "See rule documentation for <rule_id>">
 
+### Remediation
+
+**Location**: `<file>` line <line_start>–<line_end>
+**Action**: <specific, actionable description of what to change — not a restatement of the recommendation, but a concrete instruction a fixing agent can follow without additional context>
+
+```<language or text>
+// Pseudocode or minimal code snippet showing the required change.
+// If the finding includes a code sample, use it. Otherwise synthesize
+// from rule_id, file, line, and message.
+```
+
 ### Suppression
 
 If this is a confirmed false positive, add the label `security - suppressed`


### PR DESCRIPTION
## Summary

- **Reopen closed issues on re-detection**: the triager now checks recently closed `security` issues (up to 1000) after the open/suppressed checks. Matching fingerprints reopen the issue + restore `feature - ready for claude` label + add a re-detection comment, preserving fix history.
- **`feature - ready for claude` label**: added to every new issue filed and every reopened issue, so downstream fixing agents pick them up automatically.
- **`### Remediation` section in issue template**: adds file location, actionable change description, and a code snippet — enough for a fixing agent to act without additional context.
- **New `security-advisor` agent (Opus)**: Phase 3, sequential after triager+closer. Posts expert advisory comments on each acted issue: root-cause analysis and fix approach for new issues; failure-mode analysis and adjusted guidance for reopened ones. Reads from `/tmp/security-findings.json` joined on fingerprint (no N+1 GitHub API calls).
- **Label prerequisite**: `feature - ready for claude` added to the pre-flight label check with its create command.
- Version bump: `0.2.0` → `0.3.0`.

## Simplify pass fixes applied
- Closed issue fetch limit raised 200 → 1000 (matches open-issues query)
- Fingerprint included in new-issues log to enable findings join in advisor
- Unique heredoc token in advisor to prevent early termination
- Per-issue error handling in advisor loop
- TOCTOU `cat` probe replaced with contract-based read in Phase 3

## Test plan
- [ ] Run `/security-scanner` on a repo with known open security issues — confirm no regressions in filing/skipping behaviour
- [ ] Manually close a security issue, re-run — confirm it reopens rather than duplicating
- [ ] Verify `feature - ready for claude` label appears on new and reopened issues
- [ ] Verify `### Remediation` section is populated in filed issues
- [ ] Verify advisor comment appears on each filed/reopened issue after Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)