### PR TITLE
feat(security-scanner): v0.4.0 — security-advisor auto-suppresses confident false positives

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
       "name": "security-scanner",
       "source": "./plugins/security-scanner",
       "description": "Multi-tool security audit for Node.js web apps and Supabase projects — files findings as GitHub Issues with deduplication and auto-close.",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": {
         "name": "schmimran"
       }

--- a/plugins/security-scanner/.claude-plugin/plugin.json
+++ b/plugins/security-scanner/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "security-scanner",
   "description": "Multi-tool security audit for Node.js web apps and Supabase projects — files findings as GitHub Issues with deduplication and auto-close.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "schmimran"
   }

--- a/plugins/security-scanner/README.md
+++ b/plugins/security-scanner/README.md
@@ -26,6 +26,10 @@ posts expert advisory comments with root-cause analysis on each acted issue.
    gh label create "feature - ready for claude" \
      --color 0075ca \
      --description "Ready for a Claude fixing agent"
+
+   gh label create "feature - human review" \
+     --color 0075ca \
+     --description "Needs a human to review before proceeding"
    ```
 
 3. **Run a quick scan** (before feature work):
@@ -162,6 +166,28 @@ To suppress a finding permanently:
 
 The scanner will skip suppressed findings on all future runs and will never
 auto-close them.  See `references/suppression-guide.md` for details.
+
+### Autonomous suppression by the advisor
+
+The `security-advisor` agent may auto-suppress a newly filed issue when ALL
+three high-confidence false-positive signals are present:
+
+1. Source is `supabase-advisor` or `supabase-schema`.
+2. Rule ID is a known FP-prone rule for that source (`rls_disabled_in_public`,
+   `rls_enabled_no_policy`, `missing_rls`, or `policy_allows_all`).
+3. The finding references a known Supabase-internal or system table
+   (`schema_migrations`, `supabase_migrations`, `supabase_functions`,
+   `_realtime`, `_analytics`, `_supabase`, `storage.buckets`,
+   `storage.objects`).
+
+When triggered, the advisor applies `security - suppressed` and
+`feature - human review` labels, removes `feature - ready for claude`, posts
+a rationale comment, and closes the issue.  Reopened issues are never
+auto-suppressed.
+
+**To reverse an auto-suppression**: remove the `security - suppressed` label.
+The next scan re-files the issue if it is still detected.  See
+`references/suppression-guide.md` for the full signal specification.
 
 ## Advisory Comments
 

--- a/plugins/security-scanner/agents/security-advisor.md
+++ b/plugins/security-scanner/agents/security-advisor.md
@@ -127,6 +127,96 @@ Fill in the placeholders using the finding metadata retrieved in Step 1.  If
 file or line information is missing, note that in the advisory and base guidance
 on the rule and source alone.
 
+## Step 2.5: Evaluate for High-Confidence False Positive
+
+After posting the advisory comment for a `type: "new"` issue, evaluate whether
+the finding is a high-confidence false positive.  Suppression fires **only**
+when ALL THREE signals below are present simultaneously.  If any signal is
+missing, skip this step and move to the next issue.
+
+This step never runs for `type: "reopened"` issues — a re-detection means a
+prior close was incomplete, so human review is required regardless of the
+rule.
+
+### Signal 1 — Source
+
+The finding's `source` must be `supabase-advisor` or `supabase-schema`.  All
+other sources (semgrep, npm-audit, nodejsscan, etc.) fall outside the
+auto-suppression policy.
+
+### Signal 2 — Rule ID (split by source)
+
+Rule IDs are split by source.  Do not mix the two lists — a rule ID from one
+source is not automatically FP-prone under the other.
+
+- When `source == "supabase-advisor"`, suppress if `rule_id` is one of:
+  - `rls_disabled_in_public`
+  - `rls_enabled_no_policy`
+- When `source == "supabase-schema"`, suppress if `rule_id` is one of:
+  - `missing_rls`
+  - `policy_allows_all`
+
+### Signal 3 — Table name matches a known internal/system pattern
+
+The finding's `file` or `message` must reference a table whose name matches
+a known Supabase-internal or system table.  Match against this list
+(case-insensitive, allow optional schema prefix such as `storage.` or
+`auth.`):
+
+- `schema_migrations`
+- `supabase_migrations`
+- `supabase_functions`
+- `_realtime`
+- `_analytics`
+- `_supabase`
+- `buckets` (only the `storage.buckets` table)
+- `objects` (only the `storage.objects` table)
+
+If the table name does not appear in the finding metadata, do not attempt
+to guess — skip suppression (missing Signal 3).
+
+### Action when all three signals match
+
+Apply suppression.  Always use `--body-file` for the rationale comment:
+
+```bash
+cat > /tmp/sec-advisor-suppress-<NUMBER>.md << '----SUPPRESS_EOF_BOUNDARY----'
+### Security Advisor — Auto-Suppressed (False Positive)
+
+This finding has been auto-suppressed because all three false-positive
+signals are present:
+
+- Source: `<SOURCE>` (Supabase auditor)
+- Rule: `<RULE_ID>` (known FP-prone for this source)
+- Table: `<TABLE_NAME>` (known Supabase-internal / system table)
+
+Supabase-managed internal tables are not part of the user data model and
+RLS is either not applicable or managed by Supabase itself.  Filing this
+as an action item creates noise without security benefit.
+
+**To reverse**: remove the `security - suppressed` label.  The next scan
+will re-file this issue if it is still detected.  A human reviewer has
+also been flagged via the `feature - human review` label.
+----SUPPRESS_EOF_BOUNDARY----
+
+gh issue comment <NUMBER> --repo <OWNER/REPO> \
+  --body-file /tmp/sec-advisor-suppress-<NUMBER>.md
+
+gh issue edit <NUMBER> --repo <OWNER/REPO> \
+  --add-label "security - suppressed" \
+  --add-label "feature - human review" \
+  --remove-label "feature - ready for claude"
+
+gh issue close <NUMBER> --repo <OWNER/REPO> \
+  --reason "not planned"
+```
+
+If any of these `gh` commands fail, print:
+`Warning: auto-suppression partially failed on #<NUMBER> — <error>`
+and continue.  Do not abort the loop.  Count the issue as auto-suppressed
+if the suppression comment posted successfully, even if a subsequent label
+or close step failed — surface the partial failure in the warning.
+
 ## Step 3: Output
 
 Print a summary:
@@ -135,6 +225,9 @@ Print a summary:
 |--------|-------|
 | Advisory comments posted | X |
 | Advisory comments failed | X |
+| Issues auto-suppressed (false positive) | X |
 
 For each comment posted, print: `Advised on #<NUMBER>: <TITLE> (<TYPE>)`
 For each failure, print: `Failed #<NUMBER>: <error>`
+For each auto-suppressed issue, print:
+`Auto-suppressed #<NUMBER>: <RULE_ID> on <TABLE_NAME>`

--- a/plugins/security-scanner/commands/security-scanner.md
+++ b/plugins/security-scanner/commands/security-scanner.md
@@ -56,12 +56,14 @@ re-detection, close resolved ones, and post expert advisory comments.
    ```
    gh label list --repo <OWNER/REPO> --json name -q '.[].name'
    ```
-   Check for: `security`, `security - suppressed`, `feature - ready for claude`.
+   Check for: `security`, `security - suppressed`, `feature - ready for claude`,
+   `feature - human review`.
    If any are missing, print the create commands below and stop:
    ```bash
    gh label create "security" --repo <OWNER/REPO> --color "d73a4a" --description "Security finding"
    gh label create "security - suppressed" --repo <OWNER/REPO> --color "e4e669" --description "Confirmed false positive — scanner will skip"
    gh label create "feature - ready for claude" --repo <OWNER/REPO> --color "0075ca" --description "Ready for a Claude fixing agent"
+   gh label create "feature - human review" --repo <OWNER/REPO> --color "0075ca" --description "Needs a human to review before proceeding"
    ```
 
 ## Phase 1: Scan (parallel)
@@ -166,6 +168,7 @@ If the array is non-empty, launch **security-advisor**:
 
 Wait for the advisor to complete.  Collect:
 - Count of advisory comments posted
+- Count of issues auto-suppressed (false positive)
 
 ## Summary
 
@@ -185,6 +188,7 @@ Timestamp: <ISO 8601>
 - Suppressed findings skipped: X
 - Issues auto-closed (resolved): X
 - Advisory comments posted: X
+- Issues auto-suppressed (false positive): X
 
 ### Action Required
 <List any CRITICAL findings filed or reopened this run, with issue links.>

--- a/plugins/security-scanner/references/suppression-guide.md
+++ b/plugins/security-scanner/references/suppression-guide.md
@@ -1,6 +1,15 @@
 # Suppression Guide
 
-## How to Suppress a False Positive
+Suppression has two pathways:
+
+1. **Manual suppression** — a human labels an issue `security - suppressed`
+   after triaging it.
+2. **Agent-applied suppression** — the `security-advisor` auto-suppresses a
+   newly filed issue when three high-confidence false-positive signals are all
+   present.  A `feature - human review` label is applied so a human validates
+   the suppression before it becomes permanent.
+
+## How to Suppress a False Positive (Manual)
 
 1. Open the GitHub Issue for the finding.
 2. Add the label `security - suppressed` to the issue.
@@ -9,6 +18,36 @@
 
 The scanner checks for `security - suppressed` before filing duplicates and
 before auto-closing.  A suppressed issue will never be auto-closed.
+
+## Agent-Applied Suppression (Autonomous)
+
+The `security-advisor` agent may auto-suppress a newly filed issue when ALL
+THREE of the following signals are present simultaneously:
+
+1. **Source** — `supabase-advisor` or `supabase-schema`.
+2. **Rule ID** — one of a small set of rules known to be FP-prone on Supabase
+   internal tables:
+   - `supabase-advisor` source: `rls_disabled_in_public`, `rls_enabled_no_policy`
+   - `supabase-schema` source: `missing_rls`, `policy_allows_all`
+3. **Table name** — matches a known Supabase-internal or system table such as
+   `schema_migrations`, `supabase_migrations`, `supabase_functions`,
+   `_realtime`, `_analytics`, `_supabase`, `storage.buckets`, or
+   `storage.objects`.
+
+Reopened issues (`type: "reopened"`) are **never** auto-suppressed — a
+re-detection always requires human review.
+
+When all three signals match, the advisor:
+
+- Posts a rationale comment explaining the suppression.
+- Applies the `security - suppressed` label.
+- Applies the `feature - human review` label so a reviewer confirms the call.
+- Removes `feature - ready for claude` (no fix work should start).
+- Closes the issue as `not planned`.
+
+If you disagree with an auto-suppression, remove the `security - suppressed`
+label.  The next scan will re-file the issue if it is still detected.  You
+may also want to remove `feature - human review` once you have decided.
 
 ## How Suppression Works
 


### PR DESCRIPTION
## Summary

Closes #12. Expands `security-advisor` to autonomously suppress high-confidence
false positives on Supabase internal/system tables. All three signals must
fire simultaneously (source, rule, table) and reopened issues are never
auto-suppressed.

- `security-advisor` gains Step 2.5: evaluate FP signals, auto-suppress when
  all three match (close issue, apply `security - suppressed` +
  `feature - human review`, post rationale).
- Orchestrator prereq label check now includes `feature - human review`;
  summary block gains `Issues auto-suppressed (false positive)` row.
- `references/suppression-guide.md` documents the new agent-applied pathway
  and the reversal path.
- `README.md` documents autonomous suppression behavior alongside required
  labels.
- Version bump 0.3.0 → 0.4.0 synced across `plugin.json` and
  `marketplace.json`.

## Test plan

- [ ] Run scanner against a repo with `schema_migrations` RLS advisor finding — confirm auto-suppression labels and close
- [ ] Run scanner against a user-data table RLS finding (e.g. `profiles`) — confirm normal advisory only
- [ ] Confirm a `type: "reopened"` issue matching FP criteria is NOT auto-suppressed
- [ ] Confirm the suppression comment includes rule ID, rationale, and reversal instructions
- [ ] Confirm the summary block shows `Issues auto-suppressed (false positive): N`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
