### PR TITLE
feat(feature-creator): release PR auto-closes feature issues via Closes keywords

### DIFF
--- a/plugins/feature-creator/commands/feature-creator.md
+++ b/plugins/feature-creator/commands/feature-creator.md
@@ -148,21 +148,52 @@ If a merge fails, post a comment on the corresponding issue, change its label to
 
 ### 5c. Create and merge the release branch PR
 
-Create the release branch PR using `--body-file` to avoid shell injection:
+The release PR merges `stage` into `main` (the default branch). GitHub only
+auto-closes issues when a PR merges into the default branch, so this is the
+only opportunity in the pipeline to auto-close feature issues — every feature
+issue successfully merged in Phase 5b must appear as a `Closes #<N>` line in
+this PR body. Do **not** emit any explicit `gh issue close` calls; rely on
+GitHub's closing keywords.
+
+Construct the release PR body using the template in
+`references/release-pr-template.md` (read that file for the exact format).
+Populate it from the Phase 4 output:
+
+- The **Summary** section lists one line per successfully-merged feature PR,
+  including PR number, title, and issue number.
+- The **Closes** section has one `Closes #<ISSUE_NUMBER>` line per feature
+  issue that was successfully merged in Phase 5b.
+
+Only include features that were successfully merged. Features that failed to
+merge or were labeled `feature - human review` must NOT appear in the Closes
+section — those issues remain open for manual follow-up.
+
+**Pre-flight check (required before `gh pr create`).** Build the set of issue
+numbers for every PR merged successfully in Phase 5b. For each issue number,
+confirm the composed body contains a matching `Closes #<N>` line. If any
+merged issue is missing, fail with an error and stop — do not create the PR.
+This guarantees the release merge into `main` will auto-close every feature
+issue landed in this release.
+
+Write the body to `/tmp/release-pr-body.md` and create the PR with
+`--body-file`:
 
 ```
 cat > /tmp/release-pr-body.md << 'RELEASE_EOF'
-## Features in this release
-
-- #<PR_NUMBER> — <Feature title> (closes #<ISSUE_NUMBER>)
-...
-
-Automated by feature-creator.
+<POPULATED_TEMPLATE_BODY>
 RELEASE_EOF
-gh pr create --repo <OWNER/REPO> --base main --head release/<YYYY-MM-DD> --title "Release <YYYY-MM-DD>" --body-file /tmp/release-pr-body.md
-```
 
-Only include features that were successfully merged in the release PR body.
+# Pre-flight: confirm every merged issue number appears as a Closes line
+for N in <merged_issue_numbers>; do
+  if ! grep -q "^Closes #${N}\b" /tmp/release-pr-body.md; then
+    echo "ERROR: release PR body missing 'Closes #${N}' — aborting"
+    exit 1
+  fi
+done
+
+gh pr create --repo <OWNER/REPO> --base main --head release/<YYYY-MM-DD> \
+  --title "Release <YYYY-MM-DD>" --body-file /tmp/release-pr-body.md
+```
 
 **If `--auto-merge` was NOT passed**: Stop here. Print the release PR link and ask:
 > All feature PRs have been merged. Release PR: <URL>

--- a/plugins/feature-creator/references/release-pr-template.md
+++ b/plugins/feature-creator/references/release-pr-template.md
@@ -1,0 +1,47 @@
+# Release PR Template
+
+Use this template to construct the release PR body. The orchestrator
+(`commands/feature-creator.md`, Phase 5c) populates the placeholders from the
+Phase 4 implementation output.
+
+The **`Closes` section is required**. GitHub only auto-closes issues when a PR
+merges into the repository's default branch (`main`). Feature PRs merge into
+`stage`, so feature-level auto-close does not fire. The release PR is the only
+merge into `main`, so every feature issue that landed in this release must
+appear as a `Closes #<N>` line in this body — otherwise the issues will remain
+open after the release merges and require manual cleanup.
+
+Before calling `gh pr create`, the orchestrator must confirm that every
+successfully-merged feature issue from Phase 4 appears in the `Closes` section.
+Missing entries must fail the pre-flight check and block PR creation.
+
+---
+
+```markdown
+# Release <YYYY-MM-DD>
+
+## Summary
+
+This release bundles the following merged feature PRs from `stage`:
+
+- #<PR_NUMBER> — <Feature title> (issue #<ISSUE_NUMBER>)
+- #<PR_NUMBER> — <Feature title> (issue #<ISSUE_NUMBER>)
+<!-- one line per successfully-merged feature PR -->
+
+## Closes
+
+<!--
+One `Closes #<N>` line per feature issue landed in this release.
+GitHub parses these keywords on merge into the default branch and
+auto-closes the referenced issues. Do NOT remove or rename this
+section — the orchestrator's pre-flight check looks for it.
+-->
+
+Closes #<ISSUE_NUMBER>
+Closes #<ISSUE_NUMBER>
+<!-- one line per issue -->
+
+---
+
+Automated by feature-creator.
+```


### PR DESCRIPTION
## Summary

Feature PRs target `stage`; the release PR is the only merge into `main`, so it is the only opportunity for GitHub to auto-close feature issues. This PR makes the release PR body include `Closes #<N>` for every feature that landed in the release.

- **New**: `plugins/feature-creator/references/release-pr-template.md` — template with a required `Closes` section (one line per feature issue).
- **Modified**: `plugins/feature-creator/commands/feature-creator.md` Phase 5c:
  - Constructs the release PR body from the new template.
  - Adds a pre-flight check that every successfully-merged issue appears as `Closes #<N>` before `gh pr create` runs.
  - Explicitly documents that no `gh issue close` calls are emitted — GitHub closes them via the `Closes` keywords on merge into `main`.

## Test plan

- [ ] Run the pipeline end-to-end on a sandbox repo with 2+ feature issues.
- [ ] Confirm the release PR body contains `Closes #<N>` for every successfully-merged feature.
- [ ] Merge the release PR — confirm all referenced issues auto-close.
- [ ] Pre-flight check fails loudly if a merged issue is missing from the `Closes` section.

Closes #16
