### PR TITLE
feat(feature-creator): bucketing redesign for throughput + plan-race fix (#14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,15 +16,17 @@ plugins/
     .claude-plugin/
       plugin.json                 # Plugin manifest
     commands/
-      feature-creator.md          # Orchestrator command — chains the agents across five phases
+      feature-creator.md          # Orchestrator command — chains the agents across six phases (0-5)
     agents/
-      feature-planner.md          # Agent: analyze single issue, post implementation plan
-      feature-consolidator.md     # Agent: collect plans, holistic consistency review
+      feature-triager.md          # Agent (Phase 0): shared codebase exploration, bucket issues by predicted file overlap
+      feature-planner.md          # Agent: plan every issue in a bucket together, posts per-issue plan comments
+      feature-consolidator.md     # Agent: collect plans, cross-bucket conflict analysis
       feature-reviewer.md         # Agent: risk assessment, combined plan, review
       feature-implementer.md      # Agent: branch, code, test, PR
     references/
-      plan-template.md            # Template for plan comments
-      consolidated-plan-template.md # Template for consolidated plan comments
+      triage-guide.md             # Bucketing heuristics, Jaccard overlap rule, max bucket size, singleton handling
+      plan-template.md            # Template for plan comments (includes optional Bucket-mates section)
+      consolidated-plan-template.md # Bucket-centric template for consolidated plan comments
       repo-analysis-guide.md      # What to look for in the target repo
       risk-criteria.md            # Risk rubric (HIGH/MEDIUM/LOW)
       review-checklist.md         # Instructions for the review subagent

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Plugins are self-contained: each lives in its own directory with its own agents,
 
 | Plugin | Version | Description | Docs |
 |--------|---------|-------------|------|
-| [feature-creator](plugins/feature-creator/) | 0.4.0 | Feature development pipeline — GitHub issues to implementation plans to PRs | [README](plugins/feature-creator/README.md) |
+| [feature-creator](plugins/feature-creator/) | 0.5.0 | Feature development pipeline — GitHub issues to implementation plans to PRs | [README](plugins/feature-creator/README.md) |
 | [security-scanner](plugins/security-scanner/) | 0.3.0 | Multi-tool security audit for Node.js web apps — files findings as GitHub Issues with deduplication, reopen on re-detection, and expert advisory comments | [README](plugins/security-scanner/README.md) |
 
 ## What Each Plugin Does

--- a/plugins/feature-creator/README.md
+++ b/plugins/feature-creator/README.md
@@ -44,26 +44,37 @@ Automates feature development end-to-end. Point it at a GitHub repository, label
 
 | Component | Type | Model | Description |
 |-----------|------|-------|-------------|
-| `feature-creator` | Command | (inherits) | Full pipeline: plan, consolidate, review, implement, merge, clean up |
-| `feature-planner` | Agent | sonnet | Analyze a single issue and post an implementation plan |
-| `feature-consolidator` | Agent | sonnet | Collect individual plans, check consistency, create consolidated plan |
+| `feature-creator` | Command | (inherits) | Full pipeline: triage, plan, consolidate, review, implement, merge, clean up |
+| `feature-triager` | Agent | sonnet | Phase 0 — one shared codebase exploration pass, group issues into planning buckets by predicted file overlap |
+| `feature-planner` | Agent | sonnet | Plan every issue in a bucket together, using the triager's shared context |
+| `feature-consolidator` | Agent | sonnet | Collect individual plans, cross-bucket conflict analysis, consolidated plan |
 | `feature-reviewer` | Agent | sonnet | Review plans for risk, flag dangerous ones, create combined plan |
 | `feature-implementer` | Agent | opus | Create branches, write code, run tests, open PRs |
 
-The command orchestrates the four agents. Planner agents run in parallel (one per issue); all other agents run sequentially. Agents are not independently invocable — use the command to run the full pipeline.
+The command orchestrates the five agents. The triager runs once up front; planner agents run in parallel (one per bucket); all other agents run sequentially. Agents are not independently invocable — use the command to run the full pipeline.
+
+Key reference docs under `references/`:
+
+- `triage-guide.md` — bucketing heuristics, Jaccard overlap rule, max bucket size, singleton handling
+- `plan-template.md` — plan comment structure (includes optional Bucket-mates section)
+- `consolidated-plan-template.md` — bucket-centric consolidated plan structure
+- `risk-criteria.md`, `review-checklist.md`, `merge-checklist.md`, `pr-template.md`, `release-pr-template.md`, `repo-analysis-guide.md`
 
 ## Pipeline
 
 ```
 GitHub Issues                    Pipeline                            Output
  labeled
-"feature - ready       feature-planner agents (parallel)        Plan comments
- for claude"    ------> (one per issue, analyze & plan) ------> on each issue
-                                    |
+"feature - ready          feature-triager agent                  Bucket manifest
+ for claude"    ------>  (one shared exploration, ------> /tmp/feature-buckets-<TS>.json
+                          group issues into buckets)           + triage comment
+                                    |                            on each issue
+                          feature-planner agents (parallel)
+                        (one per bucket, plan together) ------> Plan comments
+                                    |                           on each issue
                           feature-consolidator agent
-                        (collect plans, consistency       ----> Consolidated plan
-                         review, holistic plan)                 on each issue
-                                    |
+                        (cross-bucket conflict analysis)  ----> Consolidated plan
+                                    |                           on each issue
                              feature-reviewer agent
                         (risk assessment, combined plan) -----> High-risk flagged
                                     |                           for human review
@@ -75,11 +86,13 @@ GitHub Issues                    Pipeline                            Output
                                                                deleted
 ```
 
-The pipeline moves through five phases:
+The pipeline moves through six phases (Phase 0 is the new triage stage):
 
-**Phase 1 — Planning**: The orchestrator gathers repository context once, then launches one planner agent per issue **in parallel**. Each planner receives the repo context and a single issue, explores the affected code, and posts a structured implementation plan as a comment. Issues that are too vague or reference non-existent files are flagged for human review.
+**Phase 0 — Triage**: The orchestrator captures a timestamp once and derives a run-scoped manifest path (`/tmp/feature-buckets-<TS>.json`). It launches the `feature-triager` agent, which fetches all trigger-labeled issues, runs **one shared codebase exploration pass**, predicts per-issue impacted globs, and groups issues into buckets by Jaccard overlap (≥ 1 shared glob). The manifest is written to the timestamped path and then validated by the orchestrator — if it is missing or malformed, the pipeline halts immediately. See `references/triage-guide.md` for the bucketing rules.
 
-**Phase 2 — Consolidation**: The consolidator agent collects all individual plans, analyzes them holistically for conflicts, missing dependencies, redundant work, and architectural inconsistencies. It produces a consolidated plan with a dependency graph, suggested implementation order, and cross-cutting concerns. Before posting, it performs a final review of the consolidated plan for internal consistency.
+**Phase 1 — Planning**: The orchestrator launches one planner agent **per bucket** (not per issue), in parallel. Each planner reads the shared context and plans every issue in its bucket together, noting shared file edits and proposing a within-bucket ordering. Each plan is posted to its own issue via a per-issue temp file (`/tmp/plan-<N>.md`). Issues too vague to plan are flagged for human review.
+
+**Phase 2 — Consolidation**: The consolidator agent reads the bucket manifest and collects all individual plans. Its analysis is scoped to **cross-bucket** concerns only — within-bucket file overlap was already resolved by each bucket-planner. It produces a bucket-centric consolidated plan with a dependency graph, suggested implementation order, and cross-cutting concerns. An explicit early-exit guard fires only for **true singleton runs** (exactly 1 bucket containing exactly 1 issue); it does NOT fire when one bucket contains multiple issues.
 
 **Phase 3 — Review**: The reviewer agent reads each plan and the consolidated plan, scores features against a risk rubric, and flags anything high-risk for human review. For approved features, it builds on the consolidator's analysis to produce a combined plan with final implementation order and conflict notes.
 

--- a/plugins/feature-creator/agents/feature-consolidator.md
+++ b/plugins/feature-creator/agents/feature-consolidator.md
@@ -16,9 +16,10 @@ and cross-cutting concerns across all features.
 
 ## Prerequisites
 
-Use the `OWNER/REPO` identifier from your prompt. The orchestrator has already verified
-`gh` authentication and label setup. If running standalone, ensure `gh auth status`
-passes and the required labels exist before proceeding.
+Use the `OWNER/REPO` identifier from your prompt. Your prompt also includes the
+**bucket manifest path** written by the triager in Phase 0 (e.g.
+`/tmp/feature-buckets-1712345678.json`). The orchestrator has already verified
+`gh` authentication and label setup.
 
 ## Step 1: Fetch Planned Issues
 
@@ -28,6 +29,59 @@ gh issue list --repo <OWNER/REPO> --label "feature - planned" --state open --jso
 ```
 
 If no issues are returned, output "No issues labeled 'feature - planned' found." and stop.
+
+## Step 1a: Read the Bucket Manifest
+
+Load the bucket structure from the path passed in your prompt:
+
+```
+python3 - "${BUCKET_MANIFEST_PATH}" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+print(f"buckets: {len(data['buckets'])}")
+for b in data["buckets"]:
+    print(f"  {b['id']}: {len(b['issues'])} issue(s) — {b['rationale']}")
+PY
+```
+
+Keep the bucket count and per-bucket issue count in memory — they drive the
+early-exit check in Step 1b and the cross-bucket conflict analysis in Step 3.
+
+## Step 1b: Early-Exit Guard (singleton run only)
+
+**Guard condition — strict.** The early-exit fires if and only if **both** of
+the following are true:
+
+1. `buckets.length == 1` — there is exactly one bucket, AND
+2. `buckets[0].issues.length == 1` — that bucket contains exactly one issue.
+
+This is a **true singleton run**: one bucket, one issue. No cross-bucket
+conflict analysis is meaningful, and no within-bucket reconciliation is
+needed (the single planner already produced the only plan).
+
+**IMPORTANT — the early-exit MUST NOT fire when:**
+- There is 1 bucket but it contains 2+ issues (the bucket-planner reasoned
+  about them together, but a consolidator pass is still valuable for
+  surfacing cross-feature concerns in the consolidated comment).
+- There are 2+ buckets (by definition cross-bucket conflict analysis is the
+  consolidator's core job).
+
+Pseudocode:
+
+```
+if len(buckets) == 1 and len(buckets[0]["issues"]) == 1:
+    # true singleton — no reconciliation work to do
+    print("Singleton run detected — skipping consolidation pass")
+    # Output a minimal summary table and stop
+    exit 0
+else:
+    # multi-issue or multi-bucket — proceed to Step 2
+    pass
+```
+
+For singleton runs, print the output summary table (see Output section) with
+"Included" for the single issue, then stop. Do **not** post a consolidated
+plan comment — the individual plan stands on its own.
 
 ## Step 2: Extract Individual Plans
 
@@ -42,24 +96,24 @@ continue with the remaining issues.
 
 ## Step 3: Analyze Holistic Consistency
 
-Review all extracted plans together. Check for:
+Review all extracted plans together, grouped by their bucket from the manifest.
+Within-bucket conflicts were already resolved by the bucket-planner — focus
+your analysis on **cross-bucket** concerns:
 
-- **Conflicting changes**: Two or more features modifying the same file in
-  incompatible ways (e.g., both restructuring the same component, both adding
-  contradictory logic to the same function)
-- **Redundant work**: Features that introduce overlapping or duplicate
-  functionality (e.g., both adding a similar utility, both creating a new
-  endpoint for the same purpose)
-- **Missing dependencies**: Feature A depending on something introduced by
-  Feature B but not explicitly stated in either plan (e.g., a new module,
-  a schema migration, a shared type)
-- **Architectural inconsistency**: Features using different patterns for the
-  same type of problem (e.g., one using REST and another using GraphQL for
-  similar endpoints, one using a context provider and another using prop
-  drilling for similar state)
+- **Cross-bucket conflicting changes**: Two features in different buckets
+  modifying the same file in incompatible ways (e.g., both restructuring the
+  same component).
+- **Cross-bucket redundant work**: Features in different buckets introducing
+  overlapping or duplicate functionality.
+- **Cross-bucket missing dependencies**: Feature in bucket A depending on
+  something introduced by a feature in bucket B that neither plan names.
+- **Architectural inconsistency**: Features across buckets using different
+  patterns for the same type of problem.
 - **Combined scope reasonableness**: Whether the total set of changes across
-  all features is achievable in a single pipeline run. Flag if the combined
-  scope exceeds ~30 files or touches deeply interconnected systems
+  all buckets is achievable in a single pipeline run. Flag if the combined
+  scope exceeds ~30 files or touches deeply interconnected systems.
+
+Do not re-analyze within-bucket file overlap — that work is already done.
 
 ## Step 4: Determine Preliminary Implementation Order
 
@@ -67,7 +121,8 @@ Order the features based on:
 1. **Dependencies** — features that produce outputs consumed by others go first
 2. **File overlap** — when two features touch the same files, order them to
    minimize merge conflicts (the one making structural changes goes first)
-3. **Logical grouping** — related features adjacent in the order
+3. **Logical grouping** — related features adjacent in the order (prefer
+   keeping bucket-mates adjacent)
 
 Do not assess risk here — that is the reviewer's responsibility.
 
@@ -75,15 +130,18 @@ Do not assess risk here — that is the reviewer's responsibility.
 
 Assemble the consolidated plan following the template in
 `consolidated-plan-template.md` (in the `references/` directory of this plugin).
-Read that file for the exact format.
+Read that file for the exact format. The template is bucket-centric: plan
+summaries are grouped by bucket, and the conflict analysis table is scoped to
+cross-bucket conflicts only.
 
 The plan must include:
 - Table of all features in the batch with plan status
+- Bucket layout (which issues are in which bucket)
 - Dependency graph between features
-- Conflict analysis with resolution recommendations
+- Cross-bucket conflict analysis with resolution recommendations
 - Suggested implementation order with rationale
 - Cross-cutting concerns (shared files, patterns, testing strategy)
-- Per-feature summaries (condensed from individual plans)
+- Per-bucket summaries (each bucket's plans condensed)
 - Issues and recommendations found during analysis
 
 ## Step 6: Final Holistic Review
@@ -102,31 +160,36 @@ agent can execute confidently without encountering surprises.
 ## Step 7: Post Consolidated Plan
 
 Post the consolidated plan as a comment on **each** planned issue, so the
-reviewer and implementer can find it from any issue. Always use `--body-file`
-to avoid shell injection:
+reviewer and implementer can find it from any issue. Use a **per-issue temp
+file** to avoid races:
+
 ```
-cat > /tmp/consolidated-plan.md << 'CONSOLIDATED_EOF'
+cat > /tmp/consolidated-plan-<ISSUE_NUMBER>.md << 'CONSOLIDATED_EOF'
+<!-- claude-feature-consolidator-v1 -->
 <CONSOLIDATED_PLAN>
 CONSOLIDATED_EOF
-gh issue comment <NUMBER> --repo <OWNER/REPO> --body-file /tmp/consolidated-plan.md
+gh issue comment <ISSUE_NUMBER> --repo <OWNER/REPO> --body-file /tmp/consolidated-plan-<ISSUE_NUMBER>.md
 ```
 
-The plan comment MUST begin with `<!-- claude-feature-consolidator-v1 -->` on the
-first line. This marker is used by downstream agents to locate the consolidated plan.
+Never write to a shared `/tmp/consolidated-plan.md` — always include the
+issue number suffix.
+
+Every comment MUST begin with `<!-- claude-feature-consolidator-v1 -->` on
+the first line.
 
 ## Error Handling
 
-If the consolidation reveals blocking inconsistencies that cannot be resolved
+If consolidation reveals blocking inconsistencies that cannot be resolved
 without human input (e.g., two features with fundamentally contradictory goals,
 a dependency on a feature whose plan is missing):
 
 1. Post a comment on the affected issue(s) explaining the blocking issue.
-   Always use `--body-file`:
+   Use a per-issue temp file:
    ```
-   cat > /tmp/consolidation-error.md << 'ERR_EOF'
+   cat > /tmp/consolidation-error-<N>.md << 'ERR_EOF'
    <ERROR_EXPLANATION>
    ERR_EOF
-   gh issue comment <NUMBER> --repo <OWNER/REPO> --body-file /tmp/consolidation-error.md
+   gh issue comment <NUMBER> --repo <OWNER/REPO> --body-file /tmp/consolidation-error-<N>.md
    ```
 
 2. Change the label on the conflicting issue(s):
@@ -136,7 +199,7 @@ a dependency on a feature whose plan is missing):
 
 3. Continue consolidating the remaining non-conflicting features. If fewer than
    2 features remain after flagging, still produce a consolidated plan for the
-   remaining feature(s).
+   remaining feature(s) — unless the early-exit guard in Step 1b applies.
 
 ## Output
 
@@ -147,3 +210,7 @@ When finished, print a summary:
 | #N | Title | Included / Flagged: <reason> / Missing plan |
 
 If any issues or recommendations were noted, list them below the table.
+
+If the early-exit was triggered (true singleton run), the table will contain
+exactly one row and no consolidated comment will have been posted — that is
+expected.

--- a/plugins/feature-creator/agents/feature-planner.md
+++ b/plugins/feature-creator/agents/feature-planner.md
@@ -1,6 +1,6 @@
 ---
 name: feature-planner
-description: Analyzes a single GitHub issue and posts an implementation plan as a comment
+description: Plans every issue in a bucket together, using shared context from the triager
 tools: Bash, Read, Grep, Glob, Agent, TodoWrite
 model: sonnet
 color: blue
@@ -9,70 +9,116 @@ disable-model-invocation: true
 
 # Feature Planner
 
-You are a feature planning agent. You analyze a single GitHub issue and design
-an implementation plan based on the repository context provided in your prompt.
-You post the plan as a comment on the issue.
+You are a feature planning agent. You receive a **bucket** of related issues
+from the triager and produce one implementation plan per issue. Because your
+bucket's issues are known to share predicted file impact, you reason about
+them together — noting shared file edits and proposing a within-bucket
+ordering — before writing each plan.
 
-## Prerequisites
+## Prompt Protocol
 
-Use the `OWNER/REPO` identifier and the issue number from your prompt. The
-orchestrator has already verified `gh` authentication and label setup.
+Your prompt contains:
 
-Your prompt includes a **repository context summary** gathered by the orchestrator.
-Use this as your primary understanding of the repo's conventions, stack, and
-structure. If you need additional context about specific files referenced in the
-issue, use Grep and Glob to explore those areas.
+- `OWNER/REPO` — target repository
+- `Bucket manifest path` — an absolute path to the JSON manifest written by
+  the triager (e.g. `/tmp/feature-buckets-1712345678.json`)
+- `Your bucket ID` — the `id` of the bucket you are responsible for
 
-## Step 1: Analyze the Issue
+Read the manifest and select your bucket:
 
-Read the issue title and body:
+```
+python3 - "${BUCKET_MANIFEST_PATH}" "${BUCKET_ID}" <<'PY' > /tmp/bucket-entry-${BUCKET_ID}.json
+import json, sys
+data = json.load(open(sys.argv[1]))
+for b in data["buckets"]:
+    if b["id"] == sys.argv[2]:
+        print(json.dumps({"shared_context": data["shared_context"], **b}))
+        break
+PY
+```
+
+The extracted entry contains `shared_context`, `issues`, `predicted_globs`,
+and `rationale`. Use `shared_context` as your primary understanding of the
+repo's conventions, stack, and structure — **do not** re-run a full codebase
+exploration. The triager already did that.
+
+## Step 1: Review the Bucket
+
+Read the bucket entry. Identify:
+
+- How many issues are in the bucket (bucket size)
+- The shared concern (rationale)
+- The predicted impacted globs (starting point for targeted exploration)
+
+List the bucket-mates for each issue (all other issues in the same bucket).
+A singleton bucket has no bucket-mates — skip any bucket-mate notation when
+writing that plan.
+
+## Step 2: Fetch Issue Bodies
+
+For each issue in the bucket:
+
 ```
 gh issue view <NUMBER> --repo <OWNER/REPO> --json title,body
 ```
 
-Identify:
-- What the feature does (functional requirements)
-- Any constraints or acceptance criteria mentioned
-- Related components or files referenced
+Identify per issue:
+- Functional requirements and constraints
+- Any explicit file references
+- Acceptance criteria
 
-## Step 2: Explore Affected Code
+## Step 3: Targeted Code Exploration
 
-Use Grep and Glob to find files that will need to change. Look for:
-- Files referenced in the issue
-- Related modules, components, or functions
-- Existing patterns for similar features
-- Test files that will need updates
+Using `Grep` and `Glob`, inspect specific files referenced in the issue
+bodies or implied by the bucket's `predicted_globs`. Do **not** repeat the
+shared codebase exploration — `shared_context` already covers conventions,
+build/test commands, and top-level layout.
 
-## Step 3: Generate the Plan
+Focus on:
+- The exact files each issue will modify
+- Existing patterns that the plans should follow
+- Overlaps between issues in the bucket (same function, same component)
 
-Create an implementation plan following the template in `plan-template.md`
-(in the `references/` directory of this plugin). Read that file for the exact
-format.
+## Step 4: Produce One Plan per Issue
 
-The plan must include:
+For every issue in the bucket, produce a plan following `plan-template.md`
+(in the `references/` directory). When bucket size > 1, include the optional
+`### Bucket-mates` section listing the other issues and a short note on any
+shared file edits or within-bucket ordering the implementer should respect.
+Omit the section for singleton buckets.
+
+Each plan must include:
 - Summary of what the feature does and why
-- List of files to create, modify, or delete
-- Numbered implementation steps with specific code changes
-- Test strategy (what tests to write or update)
-- Risk assessment (LOW / MEDIUM / HIGH for each risk factor)
-- Dependencies on other features or external systems
+- `### Bucket-mates` section (when applicable — see above)
+- Affected Files table
+- Numbered implementation steps
+- Test strategy
+- Risk assessment
+- Dependencies
 
-## Step 4: Post the Plan
+## Step 5: Post Each Plan
 
-Post the plan as a comment on the issue. Always use `--body-file` to avoid
-shell injection from issue content:
+Post every plan as a comment on its own issue. Use a **per-issue temp file**
+to prevent races when multiple planners or multiple issues in a bucket are
+written back-to-back:
+
 ```
-# Write plan to a temp file first — never use --body with untrusted content
-cat > /tmp/plan-comment.md << 'PLAN_EOF'
+cat > /tmp/plan-<ISSUE_NUMBER>.md << 'PLAN_EOF'
+<!-- claude-feature-planner-v1 -->
 <PLAN_CONTENT>
 PLAN_EOF
-gh issue comment <NUMBER> --repo <OWNER/REPO> --body-file /tmp/plan-comment.md
+gh issue comment <ISSUE_NUMBER> --repo <OWNER/REPO> --body-file /tmp/plan-<ISSUE_NUMBER>.md
 ```
 
-The plan comment MUST begin with `<!-- claude-feature-planner-v1 -->` on the
-first line. This marker is used by downstream agents to locate the plan.
+Never write to `/tmp/plan-comment.md` or any shared path. The filename
+pattern is strictly `/tmp/plan-<N>.md` where `<N>` is the issue number.
 
-## Step 5: Update the Label
+Every plan comment MUST begin with `<!-- claude-feature-planner-v1 -->` on
+the first line so downstream agents can locate it.
+
+## Step 6: Update Labels
+
+For each issue in the bucket where a plan was successfully posted:
 
 ```
 gh issue edit <NUMBER> --repo <OWNER/REPO> --remove-label "feature - ready for claude" --add-label "feature - planned"
@@ -80,18 +126,23 @@ gh issue edit <NUMBER> --repo <OWNER/REPO> --remove-label "feature - ready for c
 
 ## Error Handling
 
-If planning fails (e.g., issue body is empty, referenced files don't exist, or
-the feature is too vague to plan):
+If planning fails for an individual issue (e.g., body is empty, referenced
+files don't exist, or the feature is too vague to plan):
 
-1. Post a comment on the issue explaining what went wrong (use `--body-file`)
-2. Change the label:
+1. Post a comment on the affected issue explaining what went wrong. Write
+   the body to `/tmp/plan-error-<N>.md` and pass via `--body-file`.
+2. Change that issue's label:
    ```
    gh issue edit <NUMBER> --repo <OWNER/REPO> --remove-label "feature - ready for claude" --add-label "feature - human review"
    ```
+3. Continue planning the remaining issues in the bucket.
+
+If the bucket manifest cannot be read or parsed, stop immediately — do not
+attempt to guess the bucket contents from issue labels.
 
 ## Output
 
-When finished, print the result:
+When finished, print a summary for the bucket:
 
 | Issue | Title | Result |
 |-------|-------|--------|

--- a/plugins/feature-creator/agents/feature-triager.md
+++ b/plugins/feature-creator/agents/feature-triager.md
@@ -1,0 +1,180 @@
+---
+name: feature-triager
+description: Runs a shared codebase exploration pass and groups related issues into planning buckets by predicted file overlap
+tools: Bash, Read, Grep, Glob, TodoWrite
+model: sonnet
+color: blue
+disable-model-invocation: true
+---
+
+# Feature Triager
+
+You are a feature triage agent. You run once per pipeline execution, before any
+planner agents. Your job is to (a) gather shared repository context so that
+downstream planners do not have to repeat it, and (b) group the batch of issues
+into **buckets** of related issues that share predicted file impact. A bucket is
+planned by a single planner agent, which reduces redundant codebase exploration
+and lets related issues be reasoned about together.
+
+## Prerequisites
+
+Use the `OWNER/REPO` identifier from your prompt. Your prompt will also include
+a **bucket manifest path** (e.g. `/tmp/feature-buckets-1712345678.json`). If no
+path is passed, default to `/tmp/feature-buckets.json`, but the orchestrator is
+expected to always pass a timestamped path to avoid concurrent-run collisions.
+
+The orchestrator has already verified `gh` authentication and label setup.
+
+Read `references/triage-guide.md` (sibling of this file) for the bucketing
+heuristics, Jaccard overlap rule, bucket size cap, singleton handling, and
+rationale format. All bucketing decisions must follow that guide.
+
+## Step 1: Fetch Triggered Issues
+
+```
+gh issue list --repo <OWNER/REPO> --label "feature - ready for claude" --state open --json number,title,body,labels --limit 20
+```
+
+If 0 issues are returned, output "No issues labeled 'feature - ready for claude' found."
+and stop — do not write a manifest.
+
+## Step 2: Shared Codebase Exploration (once)
+
+Run a single exploration pass to build a `shared_context` summary. Read:
+
+- `CLAUDE.md` — conventions, build/test commands, architecture notes
+- `README.md` — project description, stack, setup
+- Package manifest — `package.json`, `Cargo.toml`, `go.mod`, `pyproject.toml`, or equivalent
+- Top-level source layout — use `Glob` for `src/`, `lib/`, `app/`, `components/`, etc.
+- Test patterns — `Glob` for `*.test.*`, `*.spec.*`, `test/`, `tests/`, `__tests__/`
+- CI/CD config — `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, `.circleci/`
+
+Summarize into a markdown block covering:
+1. Language(s) and framework(s)
+2. Test and build commands
+3. Directory conventions for new features
+4. Existing patterns relevant to this batch
+5. CI checks that must pass
+
+This block becomes the `shared_context` string in the bucket manifest. Every
+downstream planner uses it instead of re-exploring.
+
+## Step 3: Predict Per-Issue Impacted Globs
+
+For each issue, derive a set of predicted impacted file globs:
+
+1. **Explicit paths** — scan the issue body for literal paths (e.g. `src/foo/bar.ts`,
+   `plugins/feature-creator/**`) and include them verbatim.
+2. **Keyword heuristics** — apply the keyword-to-path table in
+   `references/triage-guide.md` (e.g. `auth` → `src/auth/**`).
+3. **Title signals** — check the issue title for component names that map to
+   known directories in the shared context.
+
+Each issue should end with a non-empty glob list. If none of the above produce
+a glob, tag the issue with a synthetic `__no-overlap__:<ISSUE_NUMBER>` marker
+so it lands in its own singleton bucket in Step 4.
+
+## Step 4: Bucket Issues
+
+Apply the rules from `triage-guide.md`:
+
+- Two issues share a bucket if their predicted-glob sets share **≥ 1 glob**
+  (Jaccard numerator ≥ 1).
+- Bucket size is capped at **4 issues**. If a bucket would exceed 4, split it
+  using secondary keyword affinity (see the guide).
+- Issues with the `__no-overlap__:<N>` synthetic glob become singleton buckets.
+
+Assign bucket IDs sequentially: `b1`, `b2`, …
+
+For each bucket, write a short **rationale** naming the shared concern
+(e.g. "color tokens", "feature-creator orchestrator", "auth middleware").
+
+## Step 5: Write the Bucket Manifest
+
+Write the manifest to the path passed in your prompt (or `/tmp/feature-buckets.json`
+as fallback). Use this exact structure:
+
+```json
+{
+  "shared_context": "<markdown summary from Step 2>",
+  "buckets": [
+    {
+      "id": "b1",
+      "issues": [
+        { "number": 14, "title": "..." },
+        { "number": 16, "title": "..." }
+      ],
+      "predicted_globs": ["plugins/feature-creator/**"],
+      "rationale": "feature-creator orchestrator"
+    }
+  ]
+}
+```
+
+Required top-level keys: `shared_context` (string), `buckets` (array). The
+orchestrator validates these after you complete.
+
+Write via a heredoc into the passed path. Example:
+
+```
+cat > "${BUCKET_MANIFEST_PATH}" << 'MANIFEST_EOF'
+<JSON_CONTENT>
+MANIFEST_EOF
+```
+
+After writing, confirm the file parses as JSON:
+
+```
+python3 -c "import json,sys; json.load(open('${BUCKET_MANIFEST_PATH}'))" \
+  || { echo "ERROR: triager wrote invalid JSON"; exit 1; }
+```
+
+## Step 6: Post a Triage Summary per Issue
+
+For each issue, post a triage comment listing its bucket-mates and rationale.
+Always use `--body-file` with a per-issue path:
+
+```
+cat > /tmp/triage-<NUMBER>.md << 'TRIAGE_EOF'
+<!-- claude-feature-triager-v1 -->
+## Triage Summary for #<NUMBER>
+
+**Bucket:** `<BUCKET_ID>` — <RATIONALE>
+
+**Bucket-mates:** #<M>, #<K>   (or "none — singleton bucket")
+
+**Predicted impacted globs:**
+- `<glob1>`
+- `<glob2>`
+
+This issue will be planned together with its bucket-mates by a single planner
+agent.
+TRIAGE_EOF
+gh issue comment <NUMBER> --repo <OWNER/REPO> --body-file /tmp/triage-<NUMBER>.md
+```
+
+The comment MUST begin with `<!-- claude-feature-triager-v1 -->`.
+
+Do **not** change issue labels — the planner moves issues from
+`feature - ready for claude` to `feature - planned` once the plan is posted.
+
+## Error Handling
+
+If the manifest cannot be written, or Step 5's JSON validation fails, do NOT
+post triage comments. Print a clear error message to stdout and exit non-zero.
+The orchestrator will detect the failure and halt the pipeline.
+
+If a single issue's body cannot be fetched, skip predicting globs for it and
+place it in a singleton bucket with rationale `"fetch failed — singleton fallback"`.
+The pipeline continues.
+
+## Output
+
+When finished, print:
+
+| Bucket | Issues | Rationale |
+|--------|--------|-----------|
+| b1     | #14, #16 | feature-creator orchestrator |
+| b2     | #15 | implementer reliability (singleton) |
+
+Also report the manifest path that was written.

--- a/plugins/feature-creator/commands/feature-creator.md
+++ b/plugins/feature-creator/commands/feature-creator.md
@@ -11,7 +11,8 @@ You are a feature pipeline orchestrator. You chain agents across five phases to
 take GitHub issues from labeled requests through to merged pull requests.
 
 **Pipeline**:
-1. **feature-planner** (parallel, one per issue) — Analyze repo, post individual plans
+0. **feature-triager** — Shared codebase exploration, group issues into planning buckets
+1. **feature-planner** (parallel, one per bucket) — Plan each bucket's issues together
 2. **feature-consolidator** — Holistic consistency review, consolidated plan
 3. **feature-reviewer** — Assess risk, flag dangerous features, final implementation order
 4. **feature-implementer** — Create branches, write code, run tests, open PRs
@@ -40,53 +41,115 @@ take GitHub issues from labeled requests through to merged pull requests.
    If any are missing, print the `gh label create` commands from the plugin README
    and stop.
 
+## Phase 0: Triage
+
+### 0a. Generate a timestamped bucket manifest path
+
+Capture a single timestamp **once** at the start of Phase 0 and reuse it for
+the entire pipeline run. This scopes the manifest path so concurrent pipeline
+runs on the same machine do not race on `/tmp/feature-buckets.json`.
+
+```
+PIPELINE_TS=$(date +%s)
+BUCKET_MANIFEST_PATH="/tmp/feature-buckets-${PIPELINE_TS}.json"
+echo "Bucket manifest path: ${BUCKET_MANIFEST_PATH}"
+```
+
+Record `BUCKET_MANIFEST_PATH` as a pipeline-scoped variable. You will pass it
+to the triager (Phase 0), the planners (Phase 1), and the consolidator
+(Phase 2). Do **not** re-derive it later — capture once, reuse.
+
+### 0b. Launch the triager
+
+Use the Agent tool to launch the **feature-triager** agent with this prompt:
+
+> You are the feature-triager. Target repository: <OWNER/REPO>
+> Bucket manifest path: <BUCKET_MANIFEST_PATH>
+>
+> Fetch all open issues labeled `feature - ready for claude`, run one shared
+> codebase exploration pass, group the issues into buckets per
+> `references/triage-guide.md`, write the manifest to the path above, and post
+> per-issue triage comments.
+
+Wait for the triager to complete.
+
+If the triager reports "No issues labeled 'feature - ready for claude' found.",
+stop the pipeline and report.
+
+If more than 5 issues were fetched, warn:
+> Found <N> issues — this is a large batch. The triager has grouped them into
+> <M> buckets. Consider removing the trigger label from lower-priority issues
+> to limit the batch size on future runs.
+
+### 0c. Validate the bucket manifest (Suggestion 1 — validation gate)
+
+Immediately after the triager completes, the orchestrator **must** read the
+manifest back and assert it is valid JSON with the required top-level keys.
+If the file is missing or malformed, halt the pipeline with a clear error —
+do **not** launch planners against a broken manifest.
+
+```
+# File must exist and be non-empty
+if [ ! -s "${BUCKET_MANIFEST_PATH}" ]; then
+  echo "ERROR: bucket manifest missing or empty at ${BUCKET_MANIFEST_PATH} — halting pipeline"
+  exit 1
+fi
+
+# Must parse as JSON and contain the expected top-level keys
+python3 - "${BUCKET_MANIFEST_PATH}" <<'PY'
+import json, sys
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        data = json.load(f)
+except Exception as e:
+    print(f"ERROR: bucket manifest is not valid JSON: {e}")
+    sys.exit(1)
+missing = [k for k in ("shared_context", "buckets") if k not in data]
+if missing:
+    print(f"ERROR: bucket manifest missing required keys: {missing}")
+    sys.exit(1)
+if not isinstance(data["buckets"], list) or len(data["buckets"]) == 0:
+    print("ERROR: bucket manifest has no buckets")
+    sys.exit(1)
+print(f"OK: bucket manifest valid — {len(data['buckets'])} bucket(s)")
+PY
+```
+
+If the check fails, stop the pipeline and surface the error to the user. Do
+not attempt to recover automatically — a malformed manifest indicates a
+triager bug that must be fixed before any planner can run.
+
+Load the manifest into memory for use in Phase 1:
+
+```
+BUCKET_MANIFEST_JSON=$(cat "${BUCKET_MANIFEST_PATH}")
+```
+
 ## Phase 1: Planning
 
-### 1a. Fetch Issues and Repo Context
+### 1a. Launch one planner per bucket (parallel)
 
-Fetch the full list of open issues with the trigger label:
-```
-gh issue list --repo <OWNER/REPO> --label "feature - ready for claude" --state open --json number,title,labels --limit 20
-```
+Iterate over the `buckets` array in the validated manifest. For each bucket,
+use the Agent tool to launch a **feature-planner** agent. Launch **all agents
+in a single message** so they run in parallel.
 
-If 0 issues, output "No issues labeled 'feature - ready for claude' found." and stop.
-
-If more than 5 issues, warn:
-> Found <N> issues — this is a large batch. Agents will process all of them.
-> Consider manually removing the trigger label from lower-priority issues to
-> limit the batch size for this run.
-
-Store the full issue list — you will use it to launch parallel planner agents.
-
-Next, gather repository context. Read the target repo's key files to understand
-its conventions, stack, and structure:
-- **CLAUDE.md** — project conventions, build/test commands, architecture notes
-- **README.md** — project description, setup instructions, tech stack
-- **Package manifest** — check for package.json, Cargo.toml, go.mod, pyproject.toml, or equivalent
-- **Source layout** — use Glob to identify top-level directories (src/, lib/, app/, components/, etc.)
-- **Test patterns** — use Glob to find test files (*.test.*, *.spec.*, test/, tests/, __tests__/)
-- **CI/CD config** — check .github/workflows/, .gitlab-ci.yml, Jenkinsfile, .circleci/
-
-Summarize the findings into a **repo context block** covering:
-1. Language(s) and framework(s)
-2. How to run tests and build
-3. Directory conventions for new features
-4. Existing patterns relevant to the batch of features
-5. CI checks that must pass
-
-### 1b. Parallel Planning
-
-For each issue in the list, use the Agent tool to launch a **feature-planner**
-agent. Launch **all agents in a single message** so they run in parallel. Each
-agent receives this prompt:
+Each planner receives this prompt:
 
 > You are the feature-planner. Target repository: <OWNER/REPO>
-> Plan this single issue: #<NUMBER> — <TITLE>
+> Bucket manifest path: <BUCKET_MANIFEST_PATH>
+> Your bucket ID: <BUCKET_ID>
 >
-> Repository context:
-> <REPO_CONTEXT_BLOCK>
+> Plan every issue in this bucket together. Read the bucket manifest for your
+> `shared_context`, the issues in your bucket, the predicted globs, and the
+> rationale. Produce one plan comment per issue (written to
+> `/tmp/plan-<ISSUE_NUMBER>.md`) that is aware of its bucket-mates.
 
-Wait for all parallel agents to complete. Collect results:
+Pass the full `BUCKET_MANIFEST_PATH` so each planner reads the same file that
+the triager wrote — the timestamp suffix guarantees there is no collision
+with a concurrent pipeline run.
+
+Wait for all parallel planners to complete. Collect results:
 - Which issues were successfully planned
 - Which issues were flagged for human review
 - Which issues failed with errors
@@ -99,6 +162,7 @@ If no issues were successfully planned, stop before Phase 2.
 Use the Agent tool to launch the feature-consolidator agent with the following prompt:
 
 > You are the feature-consolidator. Target repository: <OWNER/REPO>
+> Bucket manifest path: <BUCKET_MANIFEST_PATH>
 
 Wait for the agent to complete. Check its output:
 - Note any features that were flagged due to blocking inconsistencies.

--- a/plugins/feature-creator/references/consolidated-plan-template.md
+++ b/plugins/feature-creator/references/consolidated-plan-template.md
@@ -3,41 +3,61 @@
 
 ### Features in This Batch
 
-| # | Issue | Title | Individual Plan Status |
-|---|-------|-------|------------------------|
-| 1 | #N    | Title | OK / Missing plan      |
+| # | Issue | Bucket | Title | Individual Plan Status |
+|---|-------|--------|-------|------------------------|
+| 1 | #N    | b1     | Title | OK / Missing plan      |
+
+### Bucket Layout
+
+<List each bucket, its rationale from the triager, and the issues it contains.
+Within-bucket ordering was already resolved by the bucket-planner.>
+
+- **b1** — <rationale> — #N, #M
+- **b2** — <rationale> — #K
 
 ### Dependency Graph
 
-<Describe dependencies between features. Example: "#12 must precede #14 because
-#14 imports the module created by #12." If none: "No inter-feature dependencies.">
+<Describe cross-bucket dependencies between features. Example: "#12 (b1) must
+precede #14 (b2) because #14 imports the module created by #12." If none:
+"No inter-feature dependencies.">
 
-### Conflict Analysis
+### Cross-Bucket Conflict Analysis
 
-| Feature A | Feature B | Shared Files | Resolution |
-|-----------|-----------|--------------|------------|
-| #N        | #M        | `path/to/file` | <which feature goes first and why> |
+This table covers **cross-bucket** conflicts only. Within-bucket file overlap
+was already resolved by the bucket-planner — its plans note any shared file
+edits and propose within-bucket ordering.
 
-(If no conflicts: "No file conflicts detected.")
+| Feature A (bucket) | Feature B (bucket) | Shared Files | Resolution |
+|--------------------|--------------------|--------------|------------|
+| #N (b1)            | #M (b2)            | `path/to/file` | <which feature goes first and why> |
+
+(If no cross-bucket conflicts: "No cross-bucket file conflicts detected.")
 
 ### Suggested Implementation Order
 
-1. **#N — <Title>** — <rationale: e.g., "foundational, no dependencies">
-2. **#M — <Title>** — <rationale: e.g., "depends on #N's new module">
+Prefer keeping bucket-mates adjacent. Respect the within-bucket ordering
+proposed by each bucket-planner.
+
+1. **#N — <Title>** (b1) — <rationale>
+2. **#M — <Title>** (b1) — <rationale, respecting within-bucket ordering>
+3. **#K — <Title>** (b2) — <rationale>
 
 ### Cross-Cutting Concerns
 
-- <Shared patterns, conventions, or test strategies that apply across features>
-- <New dependencies or infrastructure needed by multiple features>
+- <Shared patterns, conventions, or test strategies that apply across buckets>
+- <New dependencies or infrastructure needed by multiple buckets>
 - (If none: "No cross-cutting concerns identified.")
 
-### Per-Feature Summaries
+### Per-Bucket Summaries
 
-#### #N — <Title>
-<2-3 sentence condensed plan>
+#### Bucket b1 — <rationale>
 
-#### #M — <Title>
-<2-3 sentence condensed plan>
+- **#N — <Title>** — <2-3 sentence condensed plan>
+- **#M — <Title>** — <2-3 sentence condensed plan>
+
+#### Bucket b2 — <rationale>
+
+- **#K — <Title>** — <2-3 sentence condensed plan>
 
 ### Issues and Recommendations
 

--- a/plugins/feature-creator/references/plan-template.md
+++ b/plugins/feature-creator/references/plan-template.md
@@ -13,6 +13,15 @@ downstream agents use it to locate the plan programmatically.
 ### Summary
 <2-3 sentences: what the feature does, why it matters, and the high-level approach.>
 
+### Bucket-mates
+<Optional — include only when this issue shares a planning bucket with other
+issues (bucket size > 1). Omit this section entirely for singleton buckets.>
+
+- #<M> — <title> — <short note on shared file edits or within-bucket ordering>
+- #<K> — <title> — <...>
+
+<Within-bucket ordering (if relevant): "Land #<X> before #<Y> because …">
+
 ### Affected Files
 
 | Action | File | Description |

--- a/plugins/feature-creator/references/triage-guide.md
+++ b/plugins/feature-creator/references/triage-guide.md
@@ -1,0 +1,123 @@
+# Triage Guide
+
+Heuristics and rules for grouping issues into planning buckets. Used by the
+`feature-triager` agent in Phase 0 of the feature-creator pipeline.
+
+## Goal
+
+Group issues that are likely to touch the same files into a single bucket so
+that one planner agent can reason about them together. This cuts redundant
+codebase exploration and catches within-bucket file conflicts at plan time
+instead of at implementation time.
+
+## Predicting Impacted Globs
+
+For each issue, derive a set of predicted impacted file globs using these
+signals, in order of confidence:
+
+1. **Explicit paths in the issue body.** If the body contains a literal path
+   like `src/auth/middleware.ts` or `plugins/feature-creator/**`, include it
+   verbatim. Expand bare filenames to their containing directory glob (e.g.
+   `middleware.ts` → `src/**/middleware.ts`) when the directory is unambiguous
+   from the shared context.
+
+2. **Keyword-to-path heuristics.** Apply the table below. A single issue may
+   match multiple keywords — include all matching globs.
+
+3. **Title component signals.** If the title names a known component or
+   directory (e.g. "feature-creator: …"), include that component's primary glob.
+
+### Keyword-to-Path Table
+
+| Keyword(s) in issue | Glob |
+|---------------------|------|
+| `auth`, `login`, `session`, `token` | `src/auth/**`, `**/auth/**` |
+| `style`, `color`, `theme`, `css`, `token` (visual) | `src/styles/**`, `**/*.css`, `**/theme/**` |
+| `route`, `routing`, `navigation` | `src/routes/**`, `**/router/**` |
+| `api`, `endpoint`, `handler` | `src/api/**`, `**/handlers/**`, `**/routes/**` |
+| `db`, `schema`, `migration`, `model` | `**/migrations/**`, `**/models/**`, `**/schema*` |
+| `test`, `spec`, `e2e` | `**/*.test.*`, `**/*.spec.*`, `test/**`, `tests/**` |
+| `ci`, `workflow`, `pipeline`, `action` | `.github/workflows/**`, `.gitlab-ci.yml` |
+| `doc`, `readme`, `claude.md` | `**/README.md`, `**/CLAUDE.md`, `docs/**` |
+| `config`, `env`, `settings` | `**/*.config.*`, `.env*`, `config/**` |
+| `feature-creator`, `planner`, `consolidator`, `reviewer`, `implementer`, `triager` | `plugins/feature-creator/**` |
+| `security-scanner`, `security-runner`, `security-triager`, `security-closer`, `security-advisor`, `supabase` | `plugins/security-scanner/**` |
+| `marketplace`, `plugin.json`, `plugin manifest` | `.claude-plugin/**`, `plugins/*/.claude-plugin/**` |
+
+Extend the table when recurring signals emerge. If nothing matches, the issue
+falls to a singleton bucket (see below).
+
+## Grouping Rule (Jaccard ≥ 1)
+
+Two issues share a bucket if their predicted-glob sets share **at least one
+glob** — equivalently, `|A ∩ B| ≥ 1`. Glob comparison is a literal-string match
+on normalized glob text; do not attempt to expand wildcards for comparison.
+
+Bucketing is transitive: if A shares a glob with B, and B shares a different
+glob with C, all three go in the same bucket. Start with each issue in its
+own set and union any two sets that share a glob; repeat until stable.
+
+## Maximum Bucket Size
+
+A bucket holds at most **4 issues**. If a transitive bucket would exceed 4:
+
+1. **Secondary keyword affinity.** Score every pair of issues in the bucket by
+   the number of shared keyword hits (beyond the single-glob minimum). Split
+   the oversize bucket along the weakest link — the pair with the lowest
+   secondary affinity — into two buckets. Re-check for cap compliance and
+   repeat if needed.
+2. Each resulting sub-bucket inherits the rationale suffix `"(split from <orig>)"`.
+
+The cap is a **throughput guardrail**: a single planner agent reasons more
+reliably about 4 issues than about 10. Do not exceed it.
+
+## Singleton Rule
+
+An issue with **zero glob overlap** with any other issue becomes its own
+singleton bucket. Singletons are valid and expected — the downstream planner
+handles them the same way as multi-issue buckets, just with one issue in the
+`issues` array and no "Bucket-mates" section in the plan.
+
+An issue whose body cannot be fetched is also placed in a singleton bucket
+with rationale `"fetch failed — singleton fallback"` so the pipeline can
+continue.
+
+## Rationale Format
+
+Every bucket must include a short `rationale` string naming the shared concern
+that put those issues together. Keep it to a noun phrase under 60 characters.
+
+Examples:
+
+- `"color tokens"`
+- `"feature-creator orchestrator"`
+- `"auth middleware + session handling"`
+- `"singleton — no overlap with batch"`
+- `"split from b1 — weakest secondary affinity"`
+
+The rationale is surfaced in the triage comment on each issue and in the
+consolidated plan's per-bucket summary.
+
+## Bucket Manifest Schema
+
+The triager emits this JSON structure (to the path passed by the orchestrator):
+
+```json
+{
+  "shared_context": "<markdown summary>",
+  "buckets": [
+    {
+      "id": "b1",
+      "issues": [
+        { "number": 14, "title": "..." }
+      ],
+      "predicted_globs": ["plugins/feature-creator/**"],
+      "rationale": "feature-creator orchestrator"
+    }
+  ]
+}
+```
+
+Top-level required keys: `shared_context` (string) and `buckets` (array). The
+orchestrator validates these immediately after the triager completes. A
+malformed manifest halts the pipeline.


### PR DESCRIPTION
## Summary

Closes #14.

Redesigns feature-creator planning around **buckets** of related issues instead of one-per-issue, cutting redundant codebase exploration and eliminating the `/tmp/plan-comment.md` race.

- **New Phase 0 / feature-triager agent** — runs one shared codebase exploration pass, predicts per-issue impacted globs, and groups issues into buckets by Jaccard overlap (≥ 1 shared glob). Writes a bucket manifest with `shared_context` and `buckets`.
- **feature-planner** now accepts a bucket manifest + bucket ID, reasons about every issue in its bucket together, and writes per-issue temp files (`/tmp/plan-<N>.md`).
- **feature-consolidator** reads the bucket manifest, performs cross-bucket conflict analysis only, and writes per-issue temp files (`/tmp/consolidated-plan-<N>.md`).
- **Plan / consolidated-plan templates** updated — plan template gains an optional Bucket-mates section; consolidated template is bucket-centric.
- **New reference doc** `references/triage-guide.md` documents the keyword-to-path heuristics, Jaccard rule, max bucket size (4), and singleton handling.
- **Version bump** to 0.5.0 (already applied in `plugin.json` and `marketplace.json`; this PR brings the root README in line and wires up all the supporting docs).

### Accepted reviewer suggestions (all three incorporated)

1. **Orchestrator validation gate** — after Phase 0 writes the manifest, `feature-creator.md` reads it back and asserts valid JSON with required keys (`shared_context`, `buckets`). A missing or malformed manifest halts the pipeline immediately.
2. **Timestamp-scoped manifest path** — the orchestrator captures a single `PIPELINE_TS` at the start of Phase 0 and derives `BUCKET_MANIFEST_PATH=/tmp/feature-buckets-<TS>.json`, eliminating the concurrent-run race on a shared filename. The path is passed forward to the triager, planners, and consolidator.
3. **Concrete early-exit guard in consolidator** — the early-exit fires only when `buckets.length == 1` AND `buckets[0].issues.length == 1` (a true singleton run). An explicit list in `feature-consolidator.md` names the cases where the early-exit MUST NOT fire (1 bucket with ≥ 2 issues; 2+ buckets).

## Test plan

This is a pure-markdown plugin repo — no automated tests. Manual verification:

- [ ] Run the pipeline against a repo with one `feature - ready for claude` issue → triager produces one singleton bucket; consolidator early-exits; no consolidated comment posted.
- [ ] Run with 3+ issues sharing file globs → single bucket with multiple issues; consolidator does NOT early-exit; per-issue `/tmp/plan-<N>.md` files are unique.
- [ ] Run with 3+ issues across different areas → multiple buckets; planners run in parallel; consolidator performs cross-bucket analysis.
- [ ] Corrupt the manifest mid-run → orchestrator validation gate halts with a clear error.
- [ ] Grep the modified files for `/tmp/plan-comment.md` or shared-path references → none remain.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
