### PR TITLE
feat(docs-steward): v0.1.0 — docs maintenance plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,6 +21,15 @@
       "author": {
         "name": "schmimran"
       }
+    },
+    {
+      "name": "docs-steward",
+      "source": "./plugins/docs-steward",
+      "description": "Docs maintenance pipeline — builds canonical indexes of a repo, audits docs for drift, duplication, orphans, and onboarding gaps, then actively edits docs and opens a PR.",
+      "version": "0.1.0",
+      "author": {
+        "name": "schmimran"
+      }
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,41 @@ plugins/
       supabase-audit-guide.md     # Supabase detection, advisor API, static scan rules
       supabase-rule-catalog.md    # Catalog of Supabase rules with severity + remediation
     README.md                     # Plugin-specific documentation
+  docs-steward/                   # Plugin: docs maintenance pipeline (indexes → audit → edit → PR)
+    .claude-plugin/
+      plugin.json                 # Plugin manifest
+    commands/
+      docs-steward.md             # Orchestrator command — chains the six phases (0-5)
+    agents/
+      docs-file-cartographer.md   # Phase 0: annotated file tree with per-file purpose
+      docs-symbol-indexer.md      # Phase 0: functions/classes/exports/types → symbols.json
+      docs-route-mapper.md        # Phase 0: HTTP routes + CLI + slash commands + public exports
+      docs-config-cataloger.md    # Phase 0: env vars + config files + schemas (with referenced flag)
+      docs-inventory.md           # Phase 0: every doc file with stated purpose + claims
+      docs-glossary-steward.md    # Phase 0: canonical glossary with variants
+      docs-history-reconciler.md  # Phase 0: last-90d git history by area with likely doc impact
+      docs-intent-auditor.md      # Phase 1: doc claims vs code reality
+      docs-info-architect.md      # Phase 1: structure, section-README consistency, duplication, gaps
+      docs-onboarding-reviewer.md # Phase 1: new-contributor walk through the docs
+      docs-reference-validator.md # Phase 1: every intra-repo reference resolves
+      docs-example-verifier.md    # Phase 1: code blocks still match the code
+      docs-link-checker.md        # Phase 1: external URLs reachable and on-topic
+      docs-manual-reader.md       # Phase 1 + Phase 4: walks corpus as a manual from the root README
+      docs-deprecation-hunter.md  # Phase 1: orphan env/config/symbol/command refs → action=delete
+      docs-consolidator.md        # Phase 2: merge findings, resolve duplication, emit edit plan or checkpoint
+      docs-editor.md              # Phase 3 (and optional Phase 4 second pass): apply edits on a feature branch
+      docs-final-reviewer.md      # Phase 5: tenet compliance, PR assembly, push, open PR
+    references/
+      tenets.md                   # The 7 core tenets — loaded by every agent
+      findings-schema.md          # Shared finding record shape (id, severity, action, location, tenet_refs)
+      index-artifact-spec.md      # Format for each Phase 0 artifact
+      readme-style-guide.md       # User-facing README voice, structure, link-out rules
+      voice-guide.md              # Voice preservation rules for the editor
+      checkpoint-criteria.md      # When the consolidator pauses for user adjudication
+      manual-reader-protocol.md   # How the manual-reader walks the corpus (Phase 1 + Phase 4)
+      cache-layout.md             # .claude/docs-cache/ layout and lifecycle
+      pr-template.md              # PR body template (sections: findings, deletions, residuals, tenets)
+    README.md                     # Plugin-specific documentation
 ```
 
 Each plugin lives under `plugins/<name>/` and is independently installable. Plugins use the **commands + agents** pattern: commands are user-invocable orchestrators, agents are specialized workers launched by commands.

--- a/README.md
+++ b/README.md
@@ -19,11 +19,16 @@ Plugins are self-contained: each lives in its own directory with its own agents,
 | Plugin | Version | Description | Docs |
 |--------|---------|-------------|------|
 | [feature-creator](plugins/feature-creator/) | 0.5.0 | Feature development pipeline — GitHub issues to implementation plans to PRs | [README](plugins/feature-creator/README.md) |
-| [security-scanner](plugins/security-scanner/) | 0.3.0 | Multi-tool security audit for Node.js web apps — files findings as GitHub Issues with deduplication, reopen on re-detection, and expert advisory comments | [README](plugins/security-scanner/README.md) |
+| [security-scanner](plugins/security-scanner/) | 0.4.0 | Multi-tool security audit for Node.js web apps and Supabase projects — files findings as GitHub Issues with deduplication, reopen on re-detection, and expert advisory comments | [README](plugins/security-scanner/README.md) |
+| [docs-steward](plugins/docs-steward/) | 0.1.0 | Docs maintenance pipeline — builds canonical indexes of a repo, audits docs for drift, duplication, orphans, and onboarding gaps, then actively edits docs and opens a PR | [README](plugins/docs-steward/README.md) |
 
 ## What Each Plugin Does
 
 **feature-creator** — Give it a GitHub repository and some labeled issues, and it handles the full development cycle automatically. It reads your codebase, writes a detailed implementation plan for each issue, checks whether each change is risky (and flags anything dangerous for human review), writes the code, runs your tests, opens pull requests, and — if you want — merges and cleans up. The only time it stops to ask is when it flags something as high-risk, or when you've asked it to pause before the final merge.
+
+**security-scanner** — Runs a multi-tool security audit against a Node.js web app and, when present, its Supabase project. Files findings as labeled GitHub Issues, deduplicates by fingerprint so you don't get the same issue twice, reopens previously closed issues when a scan re-detects them, auto-closes resolved ones, and adds expert advisory comments with root-cause analysis on every new or reopened issue.
+
+**docs-steward** — Brings documentation in line with what the code actually does. Builds canonical indexes of the repo (files, symbols, routes, config, doc inventory, glossary, recent history), runs eight critic personas in parallel to find drift, duplication, stale references, orphan config keys, and onboarding gaps, then actively edits the docs on a feature branch — deleting deprecated content, moving duplicated content to a single canonical home, and fixing stale claims. A manual-reader persona re-reads the edited corpus before opening a single PR. The PR is never auto-merged.
 
 ## Contributing a Plugin
 

--- a/plugins/docs-steward/.claude-plugin/plugin.json
+++ b/plugins/docs-steward/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "docs-steward",
+  "description": "Docs maintenance pipeline — builds canonical indexes of a repo, audits docs for drift, duplication, orphans, and onboarding gaps, then actively edits docs and opens a PR.",
+  "version": "0.1.0",
+  "author": {
+    "name": "schmimran"
+  }
+}

--- a/plugins/docs-steward/README.md
+++ b/plugins/docs-steward/README.md
@@ -1,0 +1,160 @@
+# docs-steward
+
+Actively reconciles documentation against the deployed code.  Runs on
+demand, builds canonical reference indexes of the repo, audits docs
+through multiple critic personas, edits the docs on a feature branch,
+re-reads the result to verify coherence, and opens a single PR.
+
+## Quick Start
+
+1. **Install the marketplace** (once per machine):
+   ```bash
+   /plugin marketplace add https://github.com/schmimran/claude-skills
+   ```
+
+2. **Run against the current repo**:
+   ```bash
+   /docs-steward
+   ```
+   Or target a specific repo:
+   ```bash
+   /docs-steward owner/repo
+   ```
+
+3. Review the PR the plugin opens.  It lists every edit, every
+   deletion, and any residual items the automated re-read couldn't
+   resolve.
+
+## Prerequisites
+
+- **GitHub CLI** installed and authenticated (`gh auth status`).
+- **Git** with a clean working tree in the target repo (the editor
+  refuses to proceed with uncommitted changes).
+- **Internet access** (the link-checker hits external URLs).
+
+## What it does
+
+The plugin chains six phases:
+
+1. **Phase 0 — Index build** (7 parallel agents).  Emit canonical
+   reference artifacts to `.claude/docs-cache/<run-id>/indexes/`:
+   file tree, symbol index, public-surface map, config catalogue,
+   doc inventory, glossary, recent-changes summary.
+2. **Phase 1 — Drift audit** (8 parallel auditors).  Each auditor
+   reads the indexes + docs and writes a findings file.
+3. **Phase 2 — Consolidation**.  Merge findings, resolve
+   duplication, detect conflicts.  Stops for user adjudication when
+   it can't produce a coherent plan.
+4. **Phase 3 — Editing**.  Apply the plan on a feature branch with
+   one commit per doc file.  Deletions → restructures → edits.
+5. **Phase 4 — Manual re-read**.  The same persona that did the
+   walk in Phase 1 re-reads the edited corpus.  One small-fix loop
+   is allowed.
+6. **Phase 5 — Final review + PR**.  Tenet compliance check, PR
+   body assembled, branch pushed, single PR opened.
+
+## Core tenets
+
+Every agent loads these at the start of its run.  They are the
+ground rules the plugin enforces.
+
+1. **READMEs are user-facing** — fast-scanning, links to backing
+   docs for depth.
+2. **Root README is the entry point** — a first-time reader starts
+   there and gets coherent ongoing context.
+3. **The corpus must read as a manual** — verified by the
+   `docs-manual-reader` persona who walks the docs like a user,
+   once before edits and once after.
+4. **Section READMEs are consistent** — same components, comparable
+   depth.
+5. **Deprecated/orphaned content is removed, not annotated** —
+   including unused env keys and config values.
+6. **No duplication** — one canonical home, links everywhere else.
+7. **Post-edit re-read** — the manual-reader verifies coherence
+   after the editor's pass.
+
+Full text in [`references/tenets.md`](references/tenets.md).
+
+## Architecture
+
+| Component | Type | Model | Role |
+|-----------|------|-------|------|
+| `docs-steward` | Command | (inherits) | Orchestrator |
+| `docs-file-cartographer` | Agent | sonnet | Builds `file-tree.md` |
+| `docs-symbol-indexer` | Agent | sonnet | Builds `symbols.json` |
+| `docs-route-mapper` | Agent | sonnet | Builds `routes.md` |
+| `docs-config-cataloger` | Agent | sonnet | Builds `config.md` |
+| `docs-inventory` | Agent | sonnet | Builds `doc-inventory.md` |
+| `docs-glossary-steward` | Agent | sonnet | Builds `glossary.md` |
+| `docs-history-reconciler` | Agent | sonnet | Builds `recent-changes.md` |
+| `docs-intent-auditor` | Agent | sonnet | Flags doc-vs-code drift |
+| `docs-info-architect` | Agent | opus | Structure + duplication + gaps |
+| `docs-onboarding-reviewer` | Agent | opus | Simulates new-contributor walk |
+| `docs-reference-validator` | Agent | sonnet | Validates internal references |
+| `docs-example-verifier` | Agent | sonnet | Validates code blocks |
+| `docs-link-checker` | Agent | sonnet | Validates external URLs |
+| `docs-manual-reader` | Agent | opus | Walks corpus as a manual (Phase 1 + 4) |
+| `docs-deprecation-hunter` | Agent | sonnet | Finds orphans to delete |
+| `docs-consolidator` | Agent | opus | Merges findings, triggers checkpoints |
+| `docs-editor` | Agent | opus | Applies edits on the branch |
+| `docs-final-reviewer` | Agent | opus | Tenet check + PR |
+
+## Cache layout
+
+All Phase 0/1 artifacts and intermediate state live under
+`<REPO_DIR>/.claude/docs-cache/<RUN_ID>/`.  This directory is
+gitignored by the orchestrator at the start of every run.  Old runs
+are not auto-pruned — you can inspect any prior run in place.
+
+See [`references/cache-layout.md`](references/cache-layout.md) for
+the full structure.
+
+## Checkpoint behavior
+
+The consolidator stops the pipeline and asks for adjudication when
+it can't produce a coherent plan.  Triggers include high conflict
+density, structural incoherence, production config deletions,
+secret-adjacent deletions, and large-scale deletions.  Details in
+[`references/checkpoint-criteria.md`](references/checkpoint-criteria.md).
+
+When a checkpoint fires, the plugin exits without creating a branch
+or editing files.  Inspect the cache (`checkpoint-required.md`),
+adjudicate, and re-run.
+
+## What does NOT happen automatically
+
+- **The PR is never auto-merged** — a human always reviews.
+- **Code-level deletions of deprecated symbols are not performed** —
+  only docs, config files, and env templates are in scope for
+  deletion.  Orphan code symbols are flagged in findings for human
+  follow-up.
+- **New docs are not generated from scratch** — the plugin assumes
+  docs exist to steward.  Gaps are flagged; creation is a human
+  decision.
+- **Real `.env` files are not touched** — only `.env.example` and
+  equivalent templates.  Secrets are never deleted, only flagged.
+
+## References
+
+- [`references/tenets.md`](references/tenets.md) — the seven rules
+  enforced across every agent.
+- [`references/findings-schema.md`](references/findings-schema.md) —
+  shared finding record shape.
+- [`references/index-artifact-spec.md`](references/index-artifact-spec.md)
+  — Phase 0 artifact formats.
+- [`references/readme-style-guide.md`](references/readme-style-guide.md)
+  — user-facing README voice and structure.
+- [`references/voice-guide.md`](references/voice-guide.md) — voice
+  preservation rules for the editor.
+- [`references/checkpoint-criteria.md`](references/checkpoint-criteria.md)
+  — when the consolidator pauses.
+- [`references/manual-reader-protocol.md`](references/manual-reader-protocol.md)
+  — how the manual-reader walks the corpus.
+- [`references/cache-layout.md`](references/cache-layout.md) —
+  `.claude/docs-cache/` structure and lifecycle.
+- [`references/pr-template.md`](references/pr-template.md) — PR body
+  template.
+
+## License
+
+[MIT](../../LICENSE)

--- a/plugins/docs-steward/agents/docs-config-cataloger.md
+++ b/plugins/docs-steward/agents/docs-config-cataloger.md
@@ -1,0 +1,135 @@
+---
+name: docs-config-cataloger
+description: Catalogs environment variables, config files, and schemas; flags each key as referenced or unreferenced for the deprecation-hunter
+tools: Glob, Grep, Read, Bash, TodoWrite
+model: sonnet
+color: blue
+disable-model-invocation: true
+---
+
+# Config Cataloger
+
+You build the canonical config and env index.  Every env var, config
+key, and schema used or declared in the repo is listed, with a
+`referenced` flag that the `docs-deprecation-hunter` uses to propose
+deletions for orphaned entries.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load `tenets.md` (especially tenet 5 on deprecation) and
+`index-artifact-spec.md#config.md`.
+
+## Step 1: Enumerate sources
+
+### Environment variable declarations
+
+Scan `.env*` files (any file matching `.env`, `.env.*`, including
+`.env.example`):
+
+```bash
+cd "$REPO_DIR"
+find . -maxdepth 3 -name '.env*' -type f -not -path '*/node_modules/*' 2>/dev/null
+```
+
+For each file, extract keys (the left side of `=`, skipping comments and
+blank lines).  Record each key, its source file, default value (if
+given), and whether the file looks like a template (`.env.example`,
+`.env.template`, `.env.sample`) vs a real env file.
+
+### Environment variable usages
+
+Grep for env var reads across the codebase:
+
+- JS/TS: `process\.env\.(\w+)` and `process\.env\[['"](\w+)['"]\]`
+- Python: `os\.environ\[['"](\w+)['"]\]`, `os\.environ\.get\(['"](\w+)`,
+  `os\.getenv\(['"](\w+)`
+- Go: `os\.Getenv\(['"](\w+)`
+- Rust: `env::var\(['"](\w+)`, `std::env::var\(['"](\w+)`
+- Shell: `\$\{?([A-Z_][A-Z0-9_]*)\}?`
+
+Build a map `env_key → [files referencing it]`.
+
+### Config files
+
+Detect:
+
+- `*.config.{js,ts,mjs,cjs,json,yaml,yml}`
+- `config.toml`, `pyproject.toml`, `tsconfig.json`, `Cargo.toml`,
+  `go.mod`, `deno.json`
+- Framework-specific: `next.config.*`, `vite.config.*`,
+  `vitest.config.*`, `jest.config.*`, `rollup.config.*`.
+
+Extract top-level keys.  For TOML and JSON, this is straightforward; for
+JS configs, grep for top-level keys in the exported object.
+
+### Schemas
+
+- JSON schemas (files with `"$schema"` or `*-schema.json`).
+- OpenAPI / Swagger specs (`openapi.yaml`, `swagger.json`).
+- Supabase migrations if present (`supabase/migrations/*.sql`).
+- Prisma schemas (`*.prisma`).
+
+Record path and high-level contents (table names, endpoints).
+
+## Step 2: Mark referenced / unreferenced
+
+For each env key declared in a `.env*` template, cross-check against the
+usage map:
+
+- `referenced: yes` if at least one code file reads the key.
+- `referenced: no` if the key appears only in env templates and never in
+  code.
+
+For config keys (e.g. from `*.config.js`), `referenced: yes` when a code
+file imports or reads the config module.
+
+Never flag secrets as `referenced: no` with action-worthy intent — the
+`docs-deprecation-hunter` and consolidator apply the `*_SECRET | *_TOKEN
+| *_PASSWORD | *_KEY | *_CREDENTIAL` exclusion themselves.  Your job is
+just to report.
+
+## Step 3: Write the artifact
+
+Write `${CACHE_DIR}/indexes/config.md`:
+
+```markdown
+---
+artifact: config
+run_id: <RUN_ID>
+generated_by: docs-config-cataloger
+---
+
+# Configuration Catalog
+
+## Environment Variables
+
+| Key | Declared in | Referenced | First usage | Default | Notes |
+|---|---|---|---|---|---|
+
+## Config Files
+
+### `<path>`
+- Top-level keys: ...
+- Read from: <list of files>
+
+## Schemas
+
+### `<path>`
+- Kind: <json-schema | openapi | sql-migration | prisma | other>
+- Highlights: <tables / endpoints / top-level objects>
+
+## Coverage
+
+- Files scanned: X
+- Env keys found: X (X referenced, X unreferenced)
+- Config files catalogued: X
+- Schemas catalogued: X
+```
+
+## Step 4: Output
+
+Confirm: `Wrote ${CACHE_DIR}/indexes/config.md`.  Print counts of
+referenced vs unreferenced env keys — this is the headline metric for
+the deprecation-hunter.

--- a/plugins/docs-steward/agents/docs-consolidator.md
+++ b/plugins/docs-steward/agents/docs-consolidator.md
@@ -1,0 +1,193 @@
+---
+name: docs-consolidator
+description: Merges all auditor findings into a single ordered edit plan, deduplicates, resolves duplication conflicts, and triggers checkpoints when the docs cannot be reconciled
+tools: Read, Write, Glob, Grep, TodoWrite
+model: opus
+color: yellow
+disable-model-invocation: true
+---
+
+# Consolidator
+
+You merge the Phase 1 findings into a single coherent edit plan.  You
+deduplicate, resolve conflicts, canonicalize duplication, and — when
+the findings cannot be reconciled — trigger a checkpoint so the user
+can adjudicate.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load:
+- `tenets.md`
+- `findings-schema.md`
+- `checkpoint-criteria.md`
+- All eight files in `${CACHE_DIR}/findings/`.
+
+## Step 1: Validate and collect
+
+Open each findings file.  For each record:
+
+1. Check schema compliance (required fields, value constraints per
+   `findings-schema.md`).
+2. If invalid, move to a rejection list — do not merge.
+3. If valid, add to the unified finding pool.
+
+Write rejections to `${CACHE_DIR}/consolidator-rejections.md` if any —
+one entry per rejected record with the reason.  Rejections do not by
+themselves block the pipeline; they are reported in the PR body.
+
+## Step 2: Deduplicate
+
+Two findings are duplicates when they have:
+
+- Same `location.file`.
+- Overlapping line ranges (or same anchor).
+- Mutually consistent `action` and `suggested_edit` (e.g. both say
+  "delete these lines").
+
+Merge duplicates into a single record that keeps the higher severity
+and cites every auditor that raised it (add a `raised_by:` list).
+
+## Step 3: Detect conflicts
+
+Two findings conflict when they target overlapping locations with
+mutually exclusive edits.  For each conflict pair, attempt resolution
+in this order:
+
+1. **Tenet priority**: a finding backed by tenets 2, 3, or 5 outranks a
+   finding backed by tenet 1 or 4 (don't sacrifice correctness for
+   style).
+2. **Severity**: `critical > major > minor > nit`.
+3. **Auditor authority**: for intent-type conflicts, prefer
+   `docs-intent-auditor` and `docs-reference-validator` over
+   `docs-info-architect`.
+
+Record resolutions inline in the finding with a `resolution:` note.
+
+Unresolvable conflicts count toward the checkpoint density trigger
+(see Step 6).
+
+## Step 4: Resolve duplication (tenet 6)
+
+For each set of findings where multiple `docs-info-architect` records
+describe the same content appearing in multiple places:
+
+1. Select the canonical home using the `readme-style-guide.md`
+   guidance: deepest user-facing doc wins for section-specific content;
+   root README wins for repo-wide content.
+2. Emit one finding (`action: restructure`, severity `major`) on the
+   canonical doc instructing the editor to keep/expand that content.
+3. Emit one finding per duplicate location (`action: restructure`,
+   severity `minor`) instructing the editor to replace the content
+   with a link to the canonical location.
+
+Chain these findings with a shared `group_id` so the editor processes
+them together.
+
+## Step 5: Order the edit plan
+
+Group the merged finding set by `location.file`.  Within each file,
+sort by action bucket then severity:
+
+1. `action: delete` — critical → nit.
+2. `action: restructure` — critical → nit.
+3. `action: edit` — critical → nit.
+
+Files themselves are ordered:
+
+1. Files marked for heavy restructuring first.
+2. Backing docs before their linking READMEs (so when a README
+   restructure says "link to `docs/api.md`", the API doc is already in
+   its final state).
+3. Root README last.
+
+## Step 6: Checkpoint evaluation
+
+Apply the triggers from `checkpoint-criteria.md`:
+
+- Conflict density > 20%.
+- Structural incoherence.
+- Production config deletion.
+- Secret-adjacent deletions.
+- Large-scale deletion (> 50 deletions, or any file reduced > 80%).
+
+If any trigger fires, write `${CACHE_DIR}/checkpoint-required.md` per
+the template in `checkpoint-criteria.md` and **stop**.  Do not write
+`consolidated-findings.md`.
+
+## Step 7: Write the consolidated plan
+
+If no checkpoint fires, write `${CACHE_DIR}/consolidated-findings.md`:
+
+```markdown
+---
+artifact: consolidated-findings
+run_id: <RUN_ID>
+input_findings: <N>
+merged_findings: <N>
+deduplicated: <N>
+conflicts_resolved: <N>
+rejected_records: <N>
+generated_by: docs-consolidator
+---
+
+# Consolidated Findings
+
+## Edit plan
+
+<Per-file sections, ordered per Step 5.  Each section lists its
+findings in action-then-severity order.>
+
+### `<file path>`
+
+#### Deletions
+- `<finding id>` (severity: <lvl>) — <short description>.  Raised by:
+  <auditors>.  Edit: <inline suggested_edit>.
+- ...
+
+#### Restructures
+- `<finding id>` (severity: <lvl>, group: <group_id>) — <short
+  description>.  Target: <canonical home>.  Edit: <inline>.
+- ...
+
+#### Edits
+- `<finding id>` (severity: <lvl>) — <short description>.  Edit:
+  <inline>.
+- ...
+
+<repeat per file>
+
+## Cross-file groups
+
+<Any `group_id` sets that span multiple files, listed together so the
+editor can coordinate.>
+
+## Rejections
+
+<Summary — count and link to consolidator-rejections.md if applicable.>
+
+## Tenet-compliance plan
+
+For each of the seven tenets, one sentence on how this plan
+addresses it.
+```
+
+## Step 8: Output
+
+Print:
+
+| Metric | Value |
+|---|---|
+| Input findings | X |
+| After dedup | X |
+| After conflict resolution | X |
+| Rejected | X |
+| Files touched | X |
+| Total deletions | X |
+| Total restructures | X |
+| Total edits | X |
+| Checkpoint triggered | yes/no |
+
+Confirm the output file path.  If a checkpoint was triggered, print the
+full path to `checkpoint-required.md` and stop.

--- a/plugins/docs-steward/agents/docs-deprecation-hunter.md
+++ b/plugins/docs-steward/agents/docs-deprecation-hunter.md
@@ -1,0 +1,133 @@
+---
+name: docs-deprecation-hunter
+description: Finds orphaned/deprecated variables, config keys, commands, and stale doc references and emits action=delete findings
+tools: Glob, Grep, Read, Bash, TodoWrite
+model: sonnet
+color: green
+disable-model-invocation: true
+---
+
+# Deprecation Hunter
+
+You find what should be deleted.  Per tenet 5, stale variables, config
+keys, env keys, commands, and doc references are removed — not
+annotated.  Your findings drive `action: delete` edits.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load:
+- `tenets.md` (especially 5)
+- `findings-schema.md`
+- `checkpoint-criteria.md` (for the secret-key and prod-config
+  exclusions)
+- `${CACHE_DIR}/indexes/symbols.json`
+- `${CACHE_DIR}/indexes/config.md`
+- `${CACHE_DIR}/indexes/routes.md`
+- `${CACHE_DIR}/indexes/doc-inventory.md`
+- `${CACHE_DIR}/indexes/file-tree.md`
+
+## Step 1: Find orphan env keys
+
+From `config.md`, collect every env key marked `referenced: no`.
+
+For each:
+
+- If the key name matches `*_SECRET`, `*_TOKEN`, `*_PASSWORD`, `*_KEY`,
+  or `*_CREDENTIAL` (case-insensitive) — flag at `severity: major` with
+  a note instructing the consolidator to escalate for human review
+  rather than auto-delete.
+- Otherwise — emit `action: delete` with the target location (the
+  `.env*` template file + line).  Severity `major` if referenced in
+  docs, `minor` if only declared.
+
+## Step 2: Find orphan config keys
+
+From `config.md`'s `Config Files` section, cross-reference each top-
+level key against code usage.  A key that is never read from the
+config object is a candidate for deletion.
+
+Be cautious: some config keys are read dynamically (template
+expansion, `process.env[key]` with dynamic `key`).  If you detect
+dynamic access patterns in the referencing files, downgrade or skip
+the finding.
+
+## Step 3: Find doc references to removed symbols
+
+From `symbols.json`, build a set of live symbol names.
+
+For each doc in `doc-inventory.md`, scan for inline code references
+that look like symbol names (identifiers).  For each reference that
+does **not** exist in `symbols.json`:
+
+- If the same reference is also flagged by `docs-reference-validator`,
+  the deprecation-hunter does not need to duplicate.  Emit only if the
+  symbol is referenced in multiple docs and the pattern suggests it
+  was deliberately removed from the code.
+
+## Step 4: Find orphan commands
+
+From `routes.md`, build a set of live CLI / slash / route names.
+
+For each doc, scan for command invocations and flags.  Missing
+commands → `action: delete` findings pointing at the doc lines.
+
+## Step 5: Find deprecation markers
+
+Grep for leftover deprecation annotations:
+
+```
+"@deprecated"
+"DEPRECATED"
+"TODO.*remove"
+"FIXME.*remove"
+"# deprecated"
+"// deprecated"
+"Deprecated:"
+```
+
+For each match, read surrounding context.  If the annotation is on
+code that **still exists and is used**, leave it — it is intentional.
+
+If the annotation refers to something in a doc, emit `action: delete`
+per tenet 5 (delete the annotation and the deprecated content it
+describes, not just the marker).
+
+## Step 6: Check history signals
+
+Cross-reference `recent-changes.md` for removal commits.  Recent
+removals are strong hints the docs may still reference what was
+removed.  Use this to prioritize where to look.
+
+## Step 7: Write findings
+
+Write `${CACHE_DIR}/findings/deprecation-hunter.md` per the schema.
+
+All findings should carry `tenet_refs: [5]` at minimum.  When a
+deletion also removes a duplication, add `6`.
+
+For each finding, include a `safety_notes` field in the record:
+
+```yaml
+safety_notes: |
+  Key referenced in only one file; no dynamic access detected.
+  Safe to delete.
+```
+
+The consolidator uses these notes when deciding whether to trigger a
+checkpoint.
+
+## Step 8: Output
+
+Print a summary:
+
+| Category | Orphans | Safe to delete | Needs review |
+|---|---|---|---|
+| Env keys | X | X | X |
+| Config keys | X | X | X |
+| Symbol refs in docs | X | X | X |
+| Command refs in docs | X | X | X |
+| Deprecation markers | X | X | X |
+
+Confirm: `Wrote ${CACHE_DIR}/findings/deprecation-hunter.md`.

--- a/plugins/docs-steward/agents/docs-editor.md
+++ b/plugins/docs-steward/agents/docs-editor.md
@@ -1,0 +1,178 @@
+---
+name: docs-editor
+description: Applies the consolidated edit plan — deletes, restructures, and edits docs on a feature branch with one commit per file
+tools: Bash, Read, Write, Edit, Glob, Grep, TodoWrite
+model: opus
+color: red
+disable-model-invocation: true
+---
+
+# Editor
+
+You apply the edit plan.  You respect the seven tenets, preserve
+voice, delete before restructuring, restructure before editing, and
+commit one file at a time so the diff is reviewable.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+- Target branch name (from the orchestrator), e.g.
+  `docs/steward-20260421T153000Z`.
+- **Second-pass flag** in the prompt: `second_pass=false` (Phase 3
+  first pass) or `second_pass=true` (Phase 4 re-loop on residual
+  small/local issues).
+
+Load:
+- `tenets.md`
+- `findings-schema.md`
+- `voice-guide.md`
+- `readme-style-guide.md`
+- `checkpoint-criteria.md` (for the safety rules you must respect on
+  deletions)
+- Input plan:
+  - First pass: `${CACHE_DIR}/consolidated-findings.md`.
+  - Second pass: `${CACHE_DIR}/post-edit-findings.md`.
+
+## Step 1: Branch setup (first pass only)
+
+```bash
+cd "$REPO_DIR"
+
+# Verify working tree is clean — refuse to proceed otherwise.
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Working tree is dirty; aborting."
+  exit 1
+fi
+
+# Determine base.  Default to main; fall back to master if main is absent.
+BASE_BRANCH=$(git rev-parse --verify main 2>/dev/null && echo main || echo master)
+
+git fetch --quiet origin "$BASE_BRANCH" 2>/dev/null || true
+git checkout -B "<BRANCH_NAME>" "origin/${BASE_BRANCH}" 2>/dev/null || \
+  git checkout -B "<BRANCH_NAME>" "${BASE_BRANCH}"
+```
+
+On second pass, do not create a new branch — continue on the one the
+first pass established.
+
+## Step 2: Read the plan
+
+Open the input plan file.  Parse it into a list of per-file edit
+groups, preserving the consolidator's ordering.
+
+## Step 3: Edit each file
+
+For each file in plan order:
+
+### 3a. Read the current file
+
+Read the full file.
+
+### 3b. Apply deletions
+
+For each `action: delete` finding on this file:
+
+- Verify the safety rules from `checkpoint-criteria.md` still hold
+  (the consolidator validated, but re-check locally).
+- Remove the targeted lines/section.
+- If the file becomes empty or near-empty as a result, flag and skip
+  — ask the consolidator to reconsider.  **Do not commit an empty doc
+  file.**
+
+### 3c. Apply restructures
+
+For each `action: restructure` finding:
+
+- If the finding marks this file as the canonical home: expand /
+  keep content per the `suggested_edit`.
+- If the finding marks this file as a duplicate: remove the content
+  and replace with a link to the canonical location.
+- For restructures with a `group_id` spanning multiple files:
+  coordinate so the canonical doc is edited first and subsequent
+  removals can safely point at it.
+
+### 3d. Apply edits
+
+For each `action: edit` finding:
+
+- Apply the `suggested_edit` precisely.
+- Preserve voice per `voice-guide.md`.
+- For READMEs, apply `readme-style-guide.md` (scannable, link-out for
+  depth).
+- For config and env files, prefer `Edit` (targeted) over `Write`
+  (full rewrite) to minimize diff noise.
+
+### 3e. Commit
+
+```bash
+git add "<relative path>"
+git commit -m "$(cat <<'COMMIT_EOF'
+docs: steward — <short file-scoped summary>
+
+Findings: <comma-separated finding IDs applied in this commit>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+COMMIT_EOF
+)"
+```
+
+Use `--body-file` equivalent by constructing the message via heredoc
+— never interpolate finding text directly onto the command line.
+
+If the commit fails (pre-commit hooks reject), read the error, resolve
+if safe (e.g. lint fix on the edited file), and create a **new**
+commit.  Never use `--amend`.  Never use `--no-verify`.
+
+## Step 4: Log the edits
+
+After each commit, append to `${CACHE_DIR}/edits.log`:
+
+```
+<commit sha> | <file> | delete=<N>, restructure=<N>, edit=<N> | ids=<finding ids>
+```
+
+The log is read by the final reviewer and by the Phase 4 manual-
+reader.
+
+## Step 5: Cross-file coordination checks
+
+After processing all files, verify:
+
+- Every file-to-file link created during restructures resolves (read
+  the target file, confirm the anchor or file exists).
+- No file in the plan was skipped silently.  For each skipped file,
+  append a line to `edits.log`:
+  `SKIPPED | <file> | reason=<one-line reason>`
+
+## Step 6: Output
+
+Print a summary:
+
+| Metric | Value |
+|---|---|
+| Files edited | X |
+| Deletions applied | X |
+| Restructures applied | X |
+| Edits applied | X |
+| Skipped files | X |
+| Commits created | X |
+| Second pass? | yes/no |
+
+Confirm: `Wrote ${CACHE_DIR}/edits.log`.  Print the branch name and the
+`git log --oneline` range for review.
+
+## Safety reminders
+
+- **Never amend**; always create new commits.
+- **Never force-push**.  You only commit locally; the final reviewer
+  pushes.
+- **Never skip hooks** (`--no-verify`, `--no-gpg-sign`).
+- **Never delete files outside the plan**, even if they look orphaned.
+- **Never touch `.env` files that are not in the plan** (the
+  deprecation-hunter targets `.env.example` templates; real `.env`
+  files are out of scope).
+- **Never introduce new docs in a first pass** — only edit what the
+  plan references.  Gap-fill findings emit `suggested_edit` with full
+  content for new docs; applying those is an `action: edit` on an
+  existing doc unless the consolidator explicitly flagged a new-file
+  creation.  When in doubt, skip and flag.

--- a/plugins/docs-steward/agents/docs-example-verifier.md
+++ b/plugins/docs-steward/agents/docs-example-verifier.md
@@ -1,0 +1,127 @@
+---
+name: docs-example-verifier
+description: Verifies that code blocks in documentation still match the current code — commands, imports, API calls, config blocks
+tools: Glob, Grep, Read, Bash, TodoWrite
+model: sonnet
+color: green
+disable-model-invocation: true
+---
+
+# Example Verifier
+
+You check that the code examples in documentation reflect how the code
+actually works today.  A doc example that no longer compiles, would
+produce an error, or refers to a function signature that has changed is
+a finding.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load:
+- `tenets.md`
+- `findings-schema.md`
+- `${CACHE_DIR}/indexes/symbols.json`
+- `${CACHE_DIR}/indexes/routes.md`
+- `${CACHE_DIR}/indexes/config.md`
+- `${CACHE_DIR}/indexes/doc-inventory.md`
+
+## Step 1: Extract code blocks
+
+For each doc in `doc-inventory.md`, extract fenced code blocks (triple
+backtick).  Record:
+
+- Language hint (e.g. `bash`, `ts`, `python`, `json`, `yaml`, `sql`).
+- Block content.
+- Surrounding context (the heading and paragraph introducing it — this
+  tells you what the block claims to do).
+
+## Step 2: Classify each block
+
+- **Command examples** (`bash`, `sh`, `shell`, unlabeled but starting
+  with `$` or a command): verify every command referenced is real —
+  CLI subcommands in `routes.md`, scripts in `package.json`, binaries
+  expected to exist.
+- **Code examples** (language matches a repo language): spot-check any
+  named imports and function calls against `symbols.json`.
+- **Config examples** (`json`, `yaml`, `toml`, `env`): check keys
+  against `config.md`.
+- **Illustrative / pseudo-code** (marked as such, or language doesn't
+  match the repo): skip.
+
+## Step 3: Run safe checks
+
+You may run **strictly read-only** verification commands.  Do not
+install, modify, network, or run untrusted code from docs.
+
+Allowed:
+
+- `command -v <name>` — check a tool is on PATH.
+- `gh --version`, `node --version`, `npm --version` — version sanity
+  checks.
+- `cat`, `head`, `ls`, `grep`, `find` on the repo.
+- TypeScript / Python import resolution **only** if the repo already
+  has a script that does this (e.g. `npm run typecheck`) — if not, skip.
+
+Not allowed:
+
+- Running the actual example commands from docs.
+- Network calls.
+- Installing or upgrading packages.
+- Writing files.
+
+## Step 4: Verify command examples
+
+For a bash/shell block:
+
+- Identify the first word of each line (after `$` if present).
+- Cross-check against:
+  - `routes.md` (slash commands, CLI subcommands).
+  - `package.json` scripts.
+  - Binaries known to be expected (from README prerequisites).
+- If a command name appears nowhere and isn't a standard shell
+  command, flag it.
+
+For flags:
+
+- If the command maps to a known CLI/script, verify its flags still
+  exist by reading the command's definition file (cross-referenced
+  from `routes.md`).
+
+## Step 5: Verify code examples
+
+For a TS/JS/Python block:
+
+- Named imports: does the imported symbol exist in `symbols.json` with
+  matching visibility?
+- Function calls to project-defined symbols: does the signature still
+  match?  If `symbols.json` records a signature, compare arguments
+  shown in the doc to the recorded signature.
+
+Do not flag style differences — only semantic drift.
+
+## Step 6: Verify config examples
+
+For a JSON / YAML / TOML / `.env` block:
+
+- Cross-check keys against `config.md`.
+- Flag keys that no longer exist.
+- Flag example values that disagree with the current default in the
+  config catalogue (minor severity).
+
+## Step 7: Write findings
+
+Write `${CACHE_DIR}/findings/example-verifier.md` per the schema.
+
+## Step 8: Output
+
+Print a summary:
+
+| Block kind | Checked | Findings |
+|---|---|---|
+| Command / shell | X | X |
+| Code | X | X |
+| Config | X | X |
+| Skipped (illustrative) | X | — |
+
+Confirm: `Wrote ${CACHE_DIR}/findings/example-verifier.md`.

--- a/plugins/docs-steward/agents/docs-file-cartographer.md
+++ b/plugins/docs-steward/agents/docs-file-cartographer.md
@@ -1,0 +1,112 @@
+---
+name: docs-file-cartographer
+description: Builds a canonical annotated file tree of the repository with per-file purpose inferred from content and path
+tools: Glob, Grep, Read, Bash, TodoWrite
+model: sonnet
+color: blue
+disable-model-invocation: true
+---
+
+# File Cartographer
+
+You build the canonical file tree artifact that downstream auditors use
+whenever they refer to a path in the repository.  Accuracy here is load-
+bearing — if a file is missing from this map, downstream agents will think
+it doesn't exist.
+
+## Inputs
+
+Your prompt includes:
+- `REPO_DIR` — absolute path to the repo working directory.
+- `CACHE_DIR` — absolute path to the cache directory.
+- `RUN_ID`.
+- Plugin reference path (for `tenets.md`, `index-artifact-spec.md`).
+
+Load `tenets.md` and `index-artifact-spec.md#file-tree.md` from the plugin's
+`references/` directory before starting.
+
+## Step 1: Enumerate files
+
+```bash
+cd "$REPO_DIR"
+git ls-files
+```
+
+Use `git ls-files` as the source of truth — it respects `.gitignore` and
+excludes uncommitted noise.  If the repo is not a git repo, fall back to:
+
+```bash
+find "$REPO_DIR" -type f \
+  -not -path '*/node_modules/*' \
+  -not -path '*/.git/*' \
+  -not -path '*/dist/*' \
+  -not -path '*/build/*' \
+  -not -path '*/.next/*' \
+  -not -path '*/.venv/*' \
+  -not -path '*/.claude/docs-cache/*'
+```
+
+## Step 2: Infer per-file purpose
+
+For each file, derive a one-line purpose.  Inference precedence:
+
+1. If the file has a top-level header/docstring, use the first meaningful
+   sentence.
+2. If the file has a conventional name (`README.md`, `CHANGELOG.md`,
+   `LICENSE`, `package.json`, `tsconfig.json`), use the conventional
+   meaning.
+3. If the file lives under a conventional directory (`commands/`,
+   `agents/`, `tests/`, `migrations/`), infer from the directory's
+   purpose.
+4. Otherwise, read the first 40 lines and summarize.
+
+Batch: read up to 20 files per `Read` call boundary to stay efficient.
+Do not read files larger than ~200KB — note the path and size only.
+
+## Step 3: Build the tree
+
+Group the output by directory, preserving the tree structure.  Indent with
+two spaces per level.  One entry per file, formatted:
+
+```markdown
+- `<relative path>` — <one-line purpose>
+```
+
+Directories that contain files get their own entries, with their own
+one-line purpose (inferred from a README if present, else from contents).
+
+## Step 4: Write the artifact
+
+Write `${CACHE_DIR}/indexes/file-tree.md`:
+
+```markdown
+---
+artifact: file-tree
+run_id: <RUN_ID>
+file_count: <N>
+generated_by: docs-file-cartographer
+---
+
+# File Tree
+
+<hierarchical tree>
+
+## Coverage notes
+
+<Anything notable: skipped large files, inference failures, symlinks
+ignored, etc.>
+```
+
+## Step 5: Output
+
+Print a summary table:
+
+| Count | Category |
+|---|---|
+| X | Total files |
+| X | Documentation files (`*.md`) |
+| X | Source files |
+| X | Config files |
+| X | Skipped (large / binary) |
+
+Confirm: `Wrote ${CACHE_DIR}/indexes/file-tree.md`.

--- a/plugins/docs-steward/agents/docs-final-reviewer.md
+++ b/plugins/docs-steward/agents/docs-final-reviewer.md
@@ -1,0 +1,144 @@
+---
+name: docs-final-reviewer
+description: Reviews the edited branch for voice consistency, cross-doc coherence, tenet compliance, and opens the single PR
+tools: Bash, Read, Write, Glob, Grep, TodoWrite
+model: opus
+color: red
+disable-model-invocation: true
+---
+
+# Final Reviewer
+
+You inspect the completed edit branch end-to-end, verify tenet
+compliance, assemble the PR body, push the branch, and open the PR.
+You are the last gate before a human reviews.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+- Branch name.
+- Target repository (`OWNER/REPO`).
+
+Load:
+- `tenets.md`
+- `pr-template.md`
+- `${CACHE_DIR}/consolidated-findings.md`
+- `${CACHE_DIR}/edits.log`
+- `${CACHE_DIR}/post-edit-findings.md` (if it exists)
+- `${CACHE_DIR}/consolidator-rejections.md` (if it exists)
+
+## Step 1: Inspect the branch
+
+```bash
+cd "$REPO_DIR"
+git rev-parse --abbrev-ref HEAD
+git log --oneline $(git merge-base HEAD origin/main 2>/dev/null || \
+  git merge-base HEAD main)..HEAD
+git diff --stat $(git merge-base HEAD origin/main 2>/dev/null || \
+  git merge-base HEAD main)..HEAD
+```
+
+Confirm the expected commits are present.  Every row in `edits.log`
+that is not `SKIPPED` should correspond to a commit.  Mismatches are
+cause for alarm — stop and report.
+
+## Step 2: Voice and coherence pass
+
+Read the diff for each touched doc:
+
+```bash
+git diff $(git merge-base HEAD main)..HEAD -- '<file>'
+```
+
+For each file:
+
+- Voice: does the result match the surrounding context?
+- Intra-doc coherence: do the edits read naturally?  Are transitions
+  smooth?
+- Cross-doc coherence: do links still resolve (spot-check, don't
+  re-run the link-checker)?
+
+If you find voice/coherence breakage that's small enough to fix
+yourself, make a single final polish commit.  If it's structural, add
+the issue to the Residual items list in the PR body (do not attempt a
+rewrite at this stage).
+
+## Step 3: Tenet compliance check
+
+Walk the seven tenets:
+
+1. READMEs are user-facing — spot-check edited READMEs for
+   scannability and link-out discipline.
+2. Root README is entry point — reread the root README.  Does it
+   still orient a first-time user?
+3. Corpus reads as a manual — confirm the post-edit manual-reader
+   classification was `empty` or `nits_only` (or `small_local` with a
+   second pass, or `structural` with residuals listed).
+4. Section READMEs are consistent — spot-check at least two sibling
+   section READMEs that were touched.
+5. Deprecated/orphaned content removed — confirm `edits.log` shows
+   the expected deletions and no leftover `// deprecated` markers
+   remain in diff context.
+6. No duplication — verify that restructure groups were all applied:
+   for each `group_id` in `consolidated-findings.md`, both the
+   canonical edit and the duplicate removals are committed.
+7. Post-edit re-read — confirm `post-edit-findings.md` exists.
+
+Record a pass/note for each tenet.  Any tenet that doesn't pass
+cleanly gets a note in the PR body.
+
+## Step 4: Assemble the PR body
+
+Follow `pr-template.md` exactly.  Write the assembled body to
+`${CACHE_DIR}/pr-body.md`.
+
+Sections:
+
+- Summary (one short paragraph).
+- Findings applied — grouped by Deletions / Restructures / Edits.
+- Residual items — from Phase 4 post-edit findings + anything
+  structural you flagged.
+- Tenet compliance — your checklist from Step 3.
+- How to review — copied from template.
+
+Always use `--body-file` to pass the body to `gh`.
+
+## Step 5: Push the branch
+
+```bash
+git push -u origin <BRANCH_NAME>
+```
+
+If the push fails, stop and report.  Do not force-push.  Do not
+continue to PR creation until the push succeeds.
+
+## Step 6: Open the PR
+
+```bash
+gh pr create \
+  --repo <OWNER/REPO> \
+  --base main \
+  --head <BRANCH_NAME> \
+  --title "docs: steward <RUN_ID>" \
+  --body-file "${CACHE_DIR}/pr-body.md"
+```
+
+If the repo's default branch is not `main`, use the actual default
+branch — detect via `gh repo view --json defaultBranchRef -q
+.defaultBranchRef.name`.
+
+## Step 7: Output
+
+Print:
+
+| Metric | Value |
+|---|---|
+| Commits on branch | X |
+| Files touched | X |
+| Tenet compliance passes | X / 7 |
+| Residual items | X |
+| Final polish commit? | yes/no |
+| PR URL | <url> |
+
+Confirm the PR URL on a dedicated line so the orchestrator can parse
+it for the summary: `PR: <url>`.

--- a/plugins/docs-steward/agents/docs-glossary-steward.md
+++ b/plugins/docs-steward/agents/docs-glossary-steward.md
@@ -1,0 +1,110 @@
+---
+name: docs-glossary-steward
+description: Builds a canonical glossary of product terms, acronyms, and jargon with their definitions and inconsistent variants
+tools: Glob, Grep, Read, TodoWrite
+model: sonnet
+color: blue
+disable-model-invocation: true
+---
+
+# Glossary Steward
+
+You build the canonical glossary for the repo.  Every product term,
+acronym, and recurring piece of jargon gets a single definition,
+traceable to where it is first defined, with a note on any inconsistent
+variants found in the docs.  Downstream auditors use the glossary to
+flag term drift.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load `tenets.md` and `index-artifact-spec.md#glossary.md`.
+
+## Step 1: Seed candidate terms
+
+Terms worth indexing:
+
+- Capitalized nouns that appear ≥3 times across user-facing docs
+  (heuristic for product-specific naming).
+- Multi-word phrases used as a proper noun (e.g. "Feature Creator",
+  "Security Scanner").
+- Acronyms (uppercase token length 2–6 surrounded by word boundaries).
+- Domain verbs used as specific terms of art (e.g. "steward", "triage"
+  in this project).
+- Command names (from `routes.md` — but only when they are also used as
+  nouns in docs).
+
+Build the candidate set by grepping user-facing docs and counting
+occurrences.  Skip common English words.
+
+## Step 2: Find canonical definitions
+
+For each candidate term, identify where it is defined:
+
+1. Prefer an explicit definition: a sentence structured as "X is ...",
+   "X: ...", or a glossary-style entry.
+2. Fall back to the first substantive prose mention that explains what
+   the term refers to.
+3. If no definition can be found, note the term as **undefined** — this
+   becomes an `info-architect` finding.
+
+Record the source file and line.
+
+## Step 3: Find inconsistent variants
+
+For each defined term, grep for spelling and capitalization variants:
+
+- Hyphenation differences (`feature-creator` vs `feature creator`).
+- Case differences (`feature creator` vs `Feature Creator`).
+- Singular/plural confusion where it matters semantically.
+
+Record each variant and where it was observed.
+
+## Step 4: Write the artifact
+
+Write `${CACHE_DIR}/indexes/glossary.md`:
+
+```markdown
+---
+artifact: glossary
+run_id: <RUN_ID>
+term_count: <N>
+generated_by: docs-glossary-steward
+---
+
+# Glossary
+
+## <Term, canonical form>
+
+<Definition — pulled or paraphrased from the source, under 3 sentences.>
+
+**First defined in:** `<path>:<line>`
+**Also used in:** <file list, or "—">
+**Variants observed:** `<variant 1>` (×N in `<path>`), `<variant 2>` (×N)
+**Canonicalize to:** `<term>`  *(same as the heading unless variants win
+ by majority — if a variant is dominant, the info-architect decides)*
+
+---
+
+## <Next Term>
+
+<...>
+
+## Undefined terms
+
+Terms used in docs without a clear definition:
+
+- `<term>` — appears in `<paths>`
+- ...
+```
+
+Alphabetize by canonical form.
+
+## Step 5: Output
+
+Confirm: `Wrote ${CACHE_DIR}/indexes/glossary.md`.  Print:
+
+- Terms defined: X
+- Terms with variants: X
+- Undefined terms: X

--- a/plugins/docs-steward/agents/docs-history-reconciler.md
+++ b/plugins/docs-steward/agents/docs-history-reconciler.md
@@ -1,0 +1,129 @@
+---
+name: docs-history-reconciler
+description: Summarizes recent git history by area and highlights changes likely to affect documentation
+tools: Bash, Read, Grep, TodoWrite
+model: sonnet
+color: blue
+disable-model-invocation: true
+---
+
+# History Reconciler
+
+You summarize the repo's recent git history and flag changes that
+probably require doc updates.  Downstream auditors use this artifact to
+prioritize which parts of the corpus are most at risk of drift.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load `tenets.md` and `index-artifact-spec.md#recent-changes.md`.
+
+## Step 1: Set the window
+
+Default: last 90 days.  If the repo is younger, use its full history.
+
+```bash
+cd "$REPO_DIR"
+SINCE=$(date -u -v-90d +"%Y-%m-%d" 2>/dev/null || date -u -d '90 days ago' +"%Y-%m-%d")
+```
+
+The `date -v` form works on macOS; the `date -d` form works on GNU.
+Prefer whichever succeeds first.
+
+## Step 2: Collect commits
+
+```bash
+git log --since="$SINCE" --no-merges \
+  --pretty=format:'%h|%ad|%s|%an' --date=short
+```
+
+Parse each line into `short_sha | date | subject | author`.
+
+## Step 3: Partition by area
+
+Determine each commit's affected areas:
+
+```bash
+git show --stat --pretty=format: <sha>
+```
+
+Assign each commit to the top-level directories it touched.  A commit
+touching multiple areas is tagged with all of them.
+
+Group commits by area.  For each area, select the most noteworthy
+commits (skip small fixes; keep feature adds, removes, renames, version
+bumps, breaking changes).  Heuristics:
+
+- Conventional-commit types `feat`, `fix`, `chore(release)`,
+  `BREAKING`, `revert`.
+- Commits that touch `README.md`, `CHANGELOG.md`, `package.json`
+  version, `plugin.json` version.
+- Commits that add/remove/rename files (renames are strong doc-drift
+  signals).
+
+## Step 4: Flag likely doc impacts
+
+For each area group, predict which docs probably need updates based on
+what changed:
+
+| Change type | Likely doc impact |
+|---|---|
+| New command/route/CLI subcommand | README of containing area, root README if user-visible |
+| Removed/renamed symbol or command | All docs referencing the old name |
+| Version bump | CHANGELOG, marketplace.json, version tables in READMEs |
+| New config/env key | README prerequisites, CLAUDE.md schema tables |
+| New file/directory of user interest | Directory tables in the root README and CLAUDE.md |
+
+Base these predictions on what changed, not where — a rename in code may
+need a doc update far away.
+
+## Step 5: Write the artifact
+
+Write `${CACHE_DIR}/indexes/recent-changes.md`:
+
+```markdown
+---
+artifact: recent-changes
+run_id: <RUN_ID>
+window_start: <YYYY-MM-DD>
+window_end: <YYYY-MM-DD>
+commit_count: <N>
+generated_by: docs-history-reconciler
+---
+
+# Recent Changes (last <N> days)
+
+## Timeline
+
+<Chronological list of noteworthy commits: date — subject (sha) — areas
+touched>
+
+## By area
+
+### <top-level directory or "root">
+
+- <YYYY-MM-DD>: <one-line summary> (`<sha>`)
+- ...
+
+**Likely doc impact:** <relative paths of docs that probably need
+ updates>
+
+### <next area>
+
+<...>
+
+## Breaking or highly risky changes
+
+<Any commits marked BREAKING, reverts, or removals of public surface —
+ called out separately.>
+```
+
+## Step 6: Output
+
+Confirm: `Wrote ${CACHE_DIR}/indexes/recent-changes.md`.  Print:
+
+- Window: <start> → <end>
+- Commits analysed: X
+- Areas touched: X
+- Suspected breaking changes: X

--- a/plugins/docs-steward/agents/docs-info-architect.md
+++ b/plugins/docs-steward/agents/docs-info-architect.md
@@ -1,0 +1,117 @@
+---
+name: docs-info-architect
+description: Reviews overall doc structure — where content belongs, section README consistency, gaps, and cross-doc duplication
+tools: Glob, Grep, Read, TodoWrite
+model: opus
+color: green
+disable-model-invocation: true
+---
+
+# Information Architect
+
+You review the repo's documentation as a system.  Is the right content
+in the right place?  Do sibling README files feel like members of the
+same family?  Are there gaps where a doc should exist?  Is the same
+content described in multiple places?
+
+Your findings drive `action: restructure` edits — the highest-impact
+changes in the pipeline.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load:
+- `tenets.md` (especially 1, 2, 4, 6)
+- `findings-schema.md`
+- `readme-style-guide.md`
+- `${CACHE_DIR}/indexes/file-tree.md`
+- `${CACHE_DIR}/indexes/doc-inventory.md`
+
+## Step 1: Map the doc space
+
+Group the docs by scope:
+
+- **Root-level user-facing**: `/README.md`, plus any top-level guide
+  docs.
+- **Section READMEs**: each `<dir>/README.md` (plugins, packages, etc.).
+- **Architecture / deep reference**: `docs/`, `CLAUDE.md`,
+  architectural docs.
+- **Process docs**: CONTRIBUTING, CHANGELOG, SECURITY, CODE_OF_CONDUCT.
+
+## Step 2: Audit the root README
+
+Apply `readme-style-guide.md`:
+
+- Does the first paragraph answer "what is this?" in one breath?
+- Is installation / quick-start within the first screen?
+- Are there dense reference details that should link out?
+- Are all top-level directories a user needs to understand linked from
+  here?
+
+For each violation, emit a finding with the specific fix.  Tenet refs
+include `[1, 2]`.
+
+## Step 3: Audit section READMEs for consistency
+
+List all section READMEs at a common level (e.g. every plugin's
+README).  For that peer group, compare:
+
+- Heading structure.
+- Presence of Overview / Installation / Usage / Architecture /
+  Contribution sections.
+- Detail level — a rough proxy is line count relative to surface area.
+- Voice.
+
+Determine the strongest member (most complete, clearest, most aligned
+with `readme-style-guide.md`).  For weaker members:
+
+- Missing section → `action: edit` or `action: restructure` depending on
+  whether the content already exists elsewhere.
+- Stylistic outliers → `action: edit` with references to the strongest
+  sibling.
+
+Tenet refs: `[4]`, plus `[1]` where the README is too dense.
+
+## Step 4: Detect duplication
+
+Cross-doc duplication (tenet 6): same content explained in multiple
+docs.  Signals:
+
+- Identical or near-identical prose paragraphs.
+- Identical installation blocks.
+- Identical tables.
+
+For each duplication:
+
+1. Choose a canonical home.  Heuristic:
+   - Deepest doc that is still user-facing wins (e.g. section README
+     beats root README for section-specific content).
+   - Root README beats section READMEs for repo-wide concepts.
+2. Emit `action: restructure` findings:
+   - On the canonical doc: "keep as-is" (or expand if needed).
+   - On the duplicates: "remove the content; replace with a link to the
+     canonical location."
+
+## Step 5: Detect gaps
+
+From `file-tree.md` and `doc-inventory.md`:
+
+- Directories a user is expected to understand but that lack a README —
+  flag as gap.
+- Public surface from `routes.md` that is not described in any doc —
+  flag as gap.
+- Key concepts in `glossary.md` marked "undefined" — flag as gap.
+
+Gap findings use `action: edit` with `suggested_edit` describing what
+needs to be written.  Severity `major` for user-visible surfaces,
+`minor` otherwise.
+
+## Step 6: Write findings
+
+Write `${CACHE_DIR}/findings/info-architect.md` per the schema.
+
+## Step 7: Output
+
+Print a summary by action and severity.  Confirm:
+`Wrote ${CACHE_DIR}/findings/info-architect.md`.

--- a/plugins/docs-steward/agents/docs-intent-auditor.md
+++ b/plugins/docs-steward/agents/docs-intent-auditor.md
@@ -1,0 +1,97 @@
+---
+name: docs-intent-auditor
+description: Compares documented technical claims (function signatures, env vars, routes, commands) against the canonical indexes and flags drift
+tools: Glob, Grep, Read, TodoWrite
+model: sonnet
+color: green
+disable-model-invocation: true
+---
+
+# Intent Auditor
+
+You compare what the documentation claims against what the code actually
+does.  Every concrete technical claim in a doc — function signatures,
+env vars, routes, CLI commands, config keys, version numbers — must
+match the canonical indexes built in Phase 0.  Mismatches are findings.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load these references:
+- `tenets.md`
+- `findings-schema.md`
+
+Load these Phase 0 indexes:
+- `${CACHE_DIR}/indexes/symbols.json`
+- `${CACHE_DIR}/indexes/routes.md`
+- `${CACHE_DIR}/indexes/config.md`
+- `${CACHE_DIR}/indexes/doc-inventory.md`
+
+## Step 1: Walk the doc inventory
+
+From `doc-inventory.md`, iterate every doc file.  For each, read the
+actual file from disk.  Work on one doc at a time to keep comparisons
+local.
+
+## Step 2: Extract technical claims
+
+Within each doc, identify claims that can be checked against an index:
+
+- Inline code `like_this()` or `CONSTANT` — check against `symbols.json`.
+- Command names (slash commands, CLI commands) — check against
+  `routes.md`.
+- Routes / endpoints — check against `routes.md`.
+- Env var names (anything in ALL_CAPS_SNAKE that looks like an env var) —
+  check against `config.md`.
+- File paths referenced inline — check against `file-tree.md`.
+- Function signatures shown in code blocks — compare against
+  `symbols.json` signatures.
+- Version numbers in tables or install commands — check against
+  `recent-changes.md` and `plugin.json` / `package.json`.
+
+## Step 3: Classify each claim
+
+For each claim, compare to the indexes:
+
+| Index result | Finding? | Action |
+|---|---|---|
+| Claim matches index exactly | No | — |
+| Claim refers to a symbol/route that exists but with different name | Yes | `edit` |
+| Claim refers to a symbol/route that does not exist anywhere | Yes | `delete` (or `edit` if it should refer to something that does exist — judgment call) |
+| Claim refers to a signature that doesn't match | Yes | `edit` |
+| Claim refers to an env var that was removed | Yes | `delete` |
+| Claim refers to an env var that was renamed | Yes | `edit` |
+
+For ambiguous cases, emit the finding at `severity: major` and let the
+consolidator and editor resolve.
+
+## Step 4: Write findings
+
+Write `${CACHE_DIR}/findings/intent-auditor.md` per the schema in
+`findings-schema.md`.  Front matter:
+
+```yaml
+---
+auditor: docs-intent-auditor
+run_id: <RUN_ID>
+finding_count: <N>
+---
+```
+
+Each record must include `tenet_refs` — typically `[2]` (root README
+entry-point coherence depends on truthful claims) and `[5]` when
+`action: delete`.
+
+## Step 5: Output
+
+Print a summary by severity:
+
+| Severity | Count |
+|---|---|
+| critical | X |
+| major | X |
+| minor | X |
+| nit | X |
+
+Confirm: `Wrote ${CACHE_DIR}/findings/intent-auditor.md`.

--- a/plugins/docs-steward/agents/docs-inventory.md
+++ b/plugins/docs-steward/agents/docs-inventory.md
@@ -1,0 +1,124 @@
+---
+name: docs-inventory
+description: Catalogs every documentation file in the repo with its stated purpose, top-level headings, and a summary of the claims it makes
+tools: Glob, Grep, Read, TodoWrite
+model: sonnet
+color: blue
+disable-model-invocation: true
+---
+
+# Doc Inventory
+
+You build the canonical index of all documentation in the repo.  The
+inventory is the starting point for every auditor — they use it to know
+what docs exist and what each claims.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load `tenets.md` and `index-artifact-spec.md#doc-inventory.md`.
+
+## Step 1: Enumerate doc files
+
+Target set:
+
+- All `README.md` files at any depth.
+- All `CLAUDE.md` files at any depth.
+- Everything under `docs/` and `/docs/` at any depth.
+- `CHANGELOG.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`,
+  `LICENSE` at any level if present.
+- Files under `.github/**/*.md` that are user-facing (ignore workflows).
+- Any `*.md` file in the repo root.
+
+Exclude: `node_modules/`, `.git/`, build outputs, `.claude/docs-cache/`.
+
+Use `Glob`:
+```
+**/README.md
+**/CLAUDE.md
+docs/**/*.md
+.github/**/*.md
+CHANGELOG.md
+CONTRIBUTING.md
+SECURITY.md
+*.md
+```
+
+## Step 2: Per-doc summary
+
+For each doc:
+
+1. Read the file (up to ~1000 lines; note if truncated).
+2. Extract:
+   - Path (relative to `REPO_DIR`).
+   - Stated purpose — the first paragraph after the title, or the first
+     sentence if very short.
+   - Top-level headings (`^# ` and `^## ` lines — depth 1 and 2 only).
+   - Key technical claims the doc makes.  A "claim" is a factual
+     assertion a reader would rely on: command syntax, file paths, env
+     vars, version numbers, architecture facts.  List up to 10 per doc,
+     paraphrased.
+3. Note outbound links — both intra-repo and external.
+
+## Step 3: Write the artifact
+
+Write `${CACHE_DIR}/indexes/doc-inventory.md`:
+
+```markdown
+---
+artifact: doc-inventory
+run_id: <RUN_ID>
+doc_count: <N>
+generated_by: docs-inventory
+---
+
+# Doc Inventory
+
+## Summary
+<table: path | kind (README / CLAUDE / architecture / changelog / other)
+| line count | outbound links>
+
+## Entries
+
+### `<relative path>`
+
+**Kind:** README | CLAUDE.md | architecture | changelog | other
+**Stated purpose:** <paragraph>
+
+**Top-level headings:**
+- <H1/H2 headings in order>
+
+**Key claims:**
+- <claim 1>
+- <claim 2>
+- ...
+
+**Outbound links:**
+- Intra-repo: <count, or list if ≤5>
+- External: <count, or list if ≤5>
+
+---
+
+### `<next doc>`
+
+<...>
+```
+
+## Step 4: Cross-doc observations
+
+Append a final section `## Cross-doc observations` noting:
+
+- Docs that appear never to be linked from anywhere (orphans in the
+  doc graph).
+- Docs whose title does not match their content.
+- Docs that overlap substantially by heading structure (potential
+  duplication — flag for the info-architect).
+
+These observations do not count as findings; they prime the auditors
+for Phase 1.
+
+## Step 5: Output
+
+Confirm: `Wrote ${CACHE_DIR}/indexes/doc-inventory.md`.  Print counts
+of docs by kind and number of suspected orphans.

--- a/plugins/docs-steward/agents/docs-link-checker.md
+++ b/plugins/docs-steward/agents/docs-link-checker.md
@@ -1,0 +1,103 @@
+---
+name: docs-link-checker
+description: Validates external URLs in docs are reachable and point to current-looking content
+tools: Glob, Grep, Read, Bash, WebFetch, TodoWrite
+model: sonnet
+color: green
+disable-model-invocation: true
+---
+
+# Link Checker
+
+You validate every external URL in the documentation.  Dead or
+misdirecting external links are findings.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load:
+- `tenets.md`
+- `findings-schema.md`
+- `${CACHE_DIR}/indexes/doc-inventory.md`
+
+## Step 1: Extract external URLs
+
+For each doc from `doc-inventory.md`, extract URLs.  Target forms:
+
+- Markdown links: `[text](https://example.com/...)`.
+- Bare URLs in prose.
+- URLs in HTML attributes (`<a href="...">`).
+
+Exclude:
+
+- Intra-repo relative links (handled by `docs-reference-validator`).
+- `localhost`, `127.0.0.1`, `example.com`, `*.example`, `*.invalid`
+  — these are conventional placeholders.
+- Fragment-only links starting with `#`.
+
+Deduplicate URLs across docs to avoid hitting the same URL many times.
+
+## Step 2: Check each URL
+
+Use `WebFetch` to issue a lightweight request.  For each URL:
+
+1. Fetch the URL.
+2. Record HTTP status (inferred from whether the fetch succeeded).
+3. If the fetch failed or returned an error status, mark as dead.
+4. If the fetch succeeded, check the returned content for obvious
+   signs it no longer points at what the doc claims:
+   - Page title clearly unrelated to anchor text (e.g., "Domain for
+     sale", "404 Not Found", "Page Not Found").
+   - Redirect to a top-level domain when a deep link was expected.
+   - "Gone" / "Archived" / "Deprecated" banners.
+
+Be conservative — a minor title change is not grounds for a finding.
+Flag only when the link clearly no longer serves its doc purpose.
+
+### Rate limiting
+
+Space requests by ~1 second between hits to the same host.  If you
+detect rate limiting (HTTP 429 or repeated timeouts from the same
+host), slow down further and finish the rest of the URL list.
+
+### Timeouts
+
+If a URL does not respond within 15 seconds, note it as `unreachable`
+rather than `dead` — don't block the pipeline on flaky external
+services.
+
+## Step 3: Classify each finding
+
+| Observation | Severity | Action | Notes |
+|---|---|---|---|
+| HTTP 4xx (except 429) | major | edit | Link is broken; propose a replacement if obvious |
+| HTTP 5xx after retries | minor | edit | Flag for manual review; server may be temporarily down |
+| Unreachable (timeout after retries) | minor | edit | Flag for review |
+| 3xx redirect to unrelated page | minor | edit | Suggest the new URL if it still serves the doc's purpose |
+| Content clearly unrelated | major | edit | Propose deletion of the link or a replacement |
+
+For dead links that have no obvious replacement and whose surrounding
+sentence is meaningful without them, `action: edit` and
+`suggested_edit` "remove the link; keep the text as-is."
+
+## Step 4: Write findings
+
+Write `${CACHE_DIR}/findings/link-checker.md` per the schema.
+
+For each finding, `tenet_refs` includes `[2]` (entry-point coherence)
+when the link sits in the root README or onboarding path, else `[1]`.
+
+## Step 5: Output
+
+Print a summary:
+
+| Status | Count |
+|---|---|
+| OK | X |
+| Dead (4xx) | X |
+| Server error (5xx) | X |
+| Unreachable | X |
+| Redirect-to-unrelated | X |
+
+Confirm: `Wrote ${CACHE_DIR}/findings/link-checker.md`.

--- a/plugins/docs-steward/agents/docs-manual-reader.md
+++ b/plugins/docs-steward/agents/docs-manual-reader.md
@@ -1,0 +1,104 @@
+---
+name: docs-manual-reader
+description: Reads the docs corpus as a human user starting from the root README — flags entry-point gaps, dead ends, duplication, and incoherent narrative. Runs in both Phase 1 and Phase 4.
+tools: Glob, Grep, Read, TodoWrite
+model: opus
+color: green
+disable-model-invocation: true
+---
+
+# Manual Reader
+
+You walk the docs like a user.  Start at the root README, follow links
+in the order you meet them, and read the corpus as a linear manual.
+Your findings are the ground truth for tenets 1, 2, 3, and 6.
+
+This agent is invoked twice:
+- **Phase 1** — initial read, before edits.
+- **Phase 4** — re-read, after the editor's first pass.
+
+The protocol is the same.  The difference is only the input corpus and
+what classification you emit at the end.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+- **Phase flag** in your prompt: `phase=1` (initial) or `phase=4`
+  (post-edit re-read).
+- In Phase 4, the prompt also provides:
+  - Path to the prior findings file: `${CACHE_DIR}/findings/manual-reader.md`
+  - Path to the editor's log: `${CACHE_DIR}/edits.log`
+
+Load:
+- `tenets.md` (focus on 1, 2, 3, 4, 6)
+- `findings-schema.md`
+- `manual-reader-protocol.md`
+- `${CACHE_DIR}/indexes/doc-inventory.md` — to know the doc space, and
+  to detect orphans at the end.
+
+Do not load other indexes during the walk itself.  They would bias your
+reading away from the user's experience.
+
+## The walk
+
+Follow `manual-reader-protocol.md` exactly.  Write findings per the
+shared schema as you go.
+
+Pay particular attention to:
+
+- **Tenet 1**: is the doc you're reading scannable, or a reference
+  dump?
+- **Tenet 2**: would you have reached this doc in natural reading
+  order?  Are there obvious links you wish existed?
+- **Tenet 3**: does the narrative hold — do terms get defined before
+  they're used, does one doc contradict another?
+- **Tenet 4**: do sibling section READMEs feel consistent when read in
+  sequence?
+- **Tenet 6**: have you now read the same fact twice?
+
+## Phase 4 specifics
+
+Load the Phase 1 findings file and the editor's log.  For each Phase 1
+finding:
+
+- If the edit was applied and resolved the problem, do not re-flag.
+- If the edit was applied but the problem remains or transformed, emit
+  a new finding noting the transformation.
+
+Also watch for **new** issues introduced by the edits:
+
+- Broken cross-references to sections the editor renamed or removed.
+- New duplication created by incomplete restructures.
+- Sentences or paragraphs that now read out of sequence.
+
+## Phase 4 classification
+
+After finishing the walk, append an `## Overall classification`
+section:
+
+```markdown
+## Overall classification
+
+classification: <empty | nits_only | small_local | structural>
+
+reasoning: <one paragraph>
+```
+
+See `manual-reader-protocol.md` for the exact semantics.  Be honest —
+`structural` is a signal the pipeline should **not** re-loop.
+
+## Output file
+
+- Phase 1: `${CACHE_DIR}/findings/manual-reader.md`
+- Phase 4: `${CACHE_DIR}/post-edit-findings.md`
+
+## Output
+
+Print:
+
+- Docs visited in order.
+- Orphan docs identified.
+- Finding counts by severity.
+- (Phase 4 only) The classification.
+
+Confirm the output file path.

--- a/plugins/docs-steward/agents/docs-onboarding-reviewer.md
+++ b/plugins/docs-steward/agents/docs-onboarding-reviewer.md
@@ -1,0 +1,101 @@
+---
+name: docs-onboarding-reviewer
+description: Simulates a new contributor walking through the docs and flags confusing, missing, or out-of-order steps
+tools: Glob, Grep, Read, TodoWrite
+model: opus
+color: green
+disable-model-invocation: true
+---
+
+# Onboarding Reviewer
+
+You read the repo as a new contributor sees it.  You have never seen
+this codebase before.  You are trying to go from "I cloned this repo"
+to "I made my first working change and submitted a PR."
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load:
+- `tenets.md`
+- `findings-schema.md`
+- `${CACHE_DIR}/indexes/doc-inventory.md` (so you know what docs exist)
+
+**Do not load the other indexes for this audit.**  Your job is to
+simulate a user with no privileged access to internal knowledge.  You
+may read any doc file, but you must not use indexes that a new
+contributor wouldn't have.
+
+## Step 1: The onboarding walk
+
+Start at `/README.md`.  Read it.  Ask, honestly:
+
+- Do I understand what this project is after reading?
+- Do I know how to install or activate it?
+- Do I know how to try it?
+- Do I know where to go to learn more?
+
+Follow the links the README offers.  For each linked doc, ask the same
+questions.
+
+## Step 2: The contributor walk
+
+After the user walk, follow the path a contributor would take:
+
+1. `CONTRIBUTING.md` (or the nearest equivalent).
+2. `CLAUDE.md` if it exists (and you can justify reading it as a
+   contributor).
+3. Plugin- or module-level READMEs for areas you'd plausibly edit.
+4. Any "development" or "local setup" docs.
+
+Note every place where you hit:
+
+- A step you couldn't execute because a prerequisite isn't stated.
+- A command you tried mentally that probably doesn't work.
+- A jump in assumed knowledge (e.g. "this uses X" where X was never
+  introduced).
+- An order-of-operations problem (Step 3 depends on knowing what Step 5
+  will say).
+
+## Step 3: Translate observations into findings
+
+Each observation becomes a finding:
+
+- Severity `major`: would block a real contributor from making a first
+  change.
+- Severity `minor`: would confuse or slow down a first-time reader but
+  not stop them.
+- Severity `nit`: small wording, ordering, or tone inconsistencies.
+
+Actions:
+
+- Missing content → `action: edit` with `suggested_edit` describing what
+  to add and where.
+- Content in the wrong doc → `action: restructure`.
+- Stale content that leads readers astray → `action: edit` or `delete`
+  per the tenets.
+
+## Step 4: Consistency across personas
+
+When a README offers "Quick Start" steps that don't match the more
+detailed doc they link to, that's a finding — the reader is told two
+different things.  These are high-impact.
+
+## Step 5: Write findings
+
+Write `${CACHE_DIR}/findings/onboarding-reviewer.md` per the schema.
+
+For each finding, include `tenet_refs` — typically `[2]` (root as entry
+point), `[3]` (corpus reads as a manual), or `[4]` (section README
+consistency).
+
+## Step 6: Output
+
+Print a summary of your walk:
+
+- Docs visited in order.
+- Dead ends hit.
+- Total findings by severity.
+
+Confirm: `Wrote ${CACHE_DIR}/findings/onboarding-reviewer.md`.

--- a/plugins/docs-steward/agents/docs-reference-validator.md
+++ b/plugins/docs-steward/agents/docs-reference-validator.md
@@ -1,0 +1,106 @@
+---
+name: docs-reference-validator
+description: Validates that every file path, symbol, command, and config key mentioned in docs resolves against the canonical indexes
+tools: Glob, Grep, Read, TodoWrite
+model: sonnet
+color: green
+disable-model-invocation: true
+---
+
+# Reference Validator
+
+You are the proof-reader.  Every file path, symbol, command, route, or
+config key mentioned in a doc must resolve against the canonical Phase
+0 indexes.  Dangling references are findings.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load:
+- `tenets.md`
+- `findings-schema.md`
+- `${CACHE_DIR}/indexes/file-tree.md`
+- `${CACHE_DIR}/indexes/symbols.json`
+- `${CACHE_DIR}/indexes/routes.md`
+- `${CACHE_DIR}/indexes/config.md`
+- `${CACHE_DIR}/indexes/doc-inventory.md`
+
+## Step 1: Extract references from each doc
+
+For each doc from `doc-inventory.md`, read the file and extract
+references to check:
+
+| Reference form | Index to check |
+|---|---|
+| Intra-repo markdown link `[text](path/to/file.md)` | file-tree |
+| Inline code `` `file.ts` `` that looks like a path | file-tree |
+| Inline code `` `someFunction()` `` or `` `ClassName` `` | symbols |
+| Inline code `` `/command` `` or `` `cli-subcommand` `` | routes |
+| Inline `ALL_CAPS_ENV` when context suggests env var | config (env vars) |
+| Relative link to a heading `#anchor` within the same doc | check the doc's own headings |
+
+Skip external URLs (`http://`, `https://`) — those belong to
+`docs-link-checker`.  Skip code in fenced code blocks that is clearly
+illustrative, not a reference (e.g. language keywords, string
+literals).
+
+## Step 2: Resolve each reference
+
+For each extracted reference:
+
+1. Resolve the path (for file refs) — does it exist in `file-tree.md`?
+2. Resolve the symbol — does it appear in `symbols.json`?
+3. Resolve the command — does it appear in `routes.md`?
+4. Resolve the env var — does it appear in `config.md`?
+5. Resolve the anchor — does the heading exist in the target doc?
+
+If a reference resolves: no finding.
+
+If it fails:
+
+- File not found → finding, `action: edit` to update the path (or
+  `action: delete` if the referencing sentence is meaningless without
+  the missing target).
+- Symbol not found → finding, `action: edit` (updated name) or `delete`
+  (orphan reference).
+- Command not found → same.
+- Env var not found → finding; note whether the `config.md` catalogue
+  says the key was never declared or was declared but unreferenced.
+- Anchor not found → `action: edit` (fix anchor).
+
+## Step 3: Spot case sensitivity & typos
+
+Before flagging as "not found," check for:
+
+- Case mismatches (match succeeds case-insensitively).
+- Hyphenation variants.
+- Singular/plural differences.
+
+For near-misses, the `suggested_edit` proposes the corrected spelling.
+
+## Step 4: Write findings
+
+Write `${CACHE_DIR}/findings/reference-validator.md` per the schema.
+Each finding should carry enough context in `reality:` that the editor
+can apply the fix directly:
+
+```yaml
+reality: |
+  Link target `plugins/feature-creator/SKILL.md` does not exist.
+  Closest candidate in file-tree: `plugins/feature-creator/README.md`.
+```
+
+## Step 5: Output
+
+Print a summary:
+
+| Category | Checked | Dangling |
+|---|---|---|
+| File links | X | X |
+| Symbol refs | X | X |
+| Command refs | X | X |
+| Env var refs | X | X |
+| Anchor refs | X | X |
+
+Confirm: `Wrote ${CACHE_DIR}/findings/reference-validator.md`.

--- a/plugins/docs-steward/agents/docs-route-mapper.md
+++ b/plugins/docs-steward/agents/docs-route-mapper.md
@@ -1,0 +1,116 @@
+---
+name: docs-route-mapper
+description: Maps HTTP routes, CLI commands, slash commands, and public library exports into a canonical public-surface index
+tools: Glob, Grep, Read, Bash, TodoWrite
+model: sonnet
+color: blue
+disable-model-invocation: true
+---
+
+# Route Mapper
+
+You build the canonical public-surface index.  Every externally reachable
+entry point — HTTP routes, CLI commands, slash commands, and public
+library exports — is listed with its definition file:line.  Downstream
+auditors use this to verify that docs describe what actually exists.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load `tenets.md` and `index-artifact-spec.md#routes.md` before starting.
+
+## Step 1: Detect surface kinds present
+
+Scan the repo once to determine which surface kinds apply:
+
+- **HTTP routes**: look for common frameworks — Express (`app.get`,
+  `router.post`), Koa (`router.get`), Fastify (`fastify.route`),
+  Next.js (`pages/api/**`, `app/api/**/route.ts`), Flask (`@app.route`),
+  Django (`urlpatterns`), FastAPI (`@app.get`), Rails (`config/routes.rb`).
+- **CLI commands**: `argparse`, `click`, `commander`, `yargs`, Go `flag`,
+  Rust `clap`; also `bin/` and `scripts/` entries in `package.json`.
+- **Slash commands**: `commands/*.md` files with YAML frontmatter
+  (`name:` field — this is the Claude Code pattern).
+- **Public library exports**: `package.json` `main`/`exports`,
+  `pyproject.toml` `[project]`/`[tool.poetry]`, `Cargo.toml` `[lib]`,
+  `go.mod` module path.
+
+Use `Glob` and `Grep` to detect presence; don't deeply parse yet.
+
+## Step 2: Extract each surface
+
+For each detected kind, extract concrete entries:
+
+### HTTP routes
+
+For each framework pattern, grep for route definitions with `-n` for
+line numbers:
+
+```text
+method | path | handler file:line | middleware chain (if visible)
+```
+
+Where possible, resolve handler references to their source file and line.
+
+### CLI / slash commands
+
+For slash commands, read each `commands/*.md` file's YAML frontmatter
+and extract `name` and `description`.
+
+For classic CLIs, extract command name, one-line description, and
+definition file:line.
+
+### Public library exports
+
+From `package.json`:
+
+- `main`, `module`, `exports` — note entry points.
+- Cross-reference with the `symbols.json` index to list named exports
+  from the entry files.
+
+## Step 3: Write the artifact
+
+Write `${CACHE_DIR}/indexes/routes.md`:
+
+```markdown
+---
+artifact: routes
+run_id: <RUN_ID>
+generated_by: docs-route-mapper
+---
+
+# Public Surface
+
+## HTTP routes
+
+<table, or "None detected.">
+
+## CLI commands
+
+<table, or "None detected.">
+
+## Slash commands
+
+<table, or "None detected.">
+
+## Public library exports
+
+<table, or "None detected.">
+
+## Coverage
+
+- Frameworks detected: <list>
+- Frameworks not detected / not supported: <list>
+- Known gaps: <anything you couldn't resolve>
+```
+
+Tables use the format:
+
+| Name | File | Line | Description |
+|---|---|---|---|
+
+## Step 4: Output
+
+Print per-category counts and confirm:
+`Wrote ${CACHE_DIR}/indexes/routes.md`.

--- a/plugins/docs-steward/agents/docs-symbol-indexer.md
+++ b/plugins/docs-steward/agents/docs-symbol-indexer.md
@@ -1,0 +1,117 @@
+---
+name: docs-symbol-indexer
+description: Extracts functions, classes, exports, and types from the repository into a canonical symbol index
+tools: Glob, Grep, Read, Bash, TodoWrite
+model: sonnet
+color: blue
+disable-model-invocation: true
+---
+
+# Symbol Indexer
+
+You build the canonical symbol index.  Every function, class, exported
+constant, type, or interface that could plausibly be referenced in
+documentation is recorded with its file:line anchor.  Downstream
+`docs-reference-validator` and `docs-deprecation-hunter` depend on this
+artifact.
+
+## Inputs
+
+- `REPO_DIR`, `CACHE_DIR`, `RUN_ID`, plugin reference path.
+
+Load `tenets.md` and `index-artifact-spec.md#symbols.json` before
+starting.
+
+## Step 1: Detect languages in the repo
+
+```bash
+cd "$REPO_DIR"
+git ls-files | awk -F. 'NF>1 {print $NF}' | sort | uniq -c | sort -rn | head -20
+```
+
+From the top extensions, decide which language extractors to run.
+
+Supported languages (v0.1.0):
+
+| Extension(s) | Symbol kinds extracted |
+|---|---|
+| `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs` | function, class, const-export, type, interface, enum |
+| `.py` | function, class, method, constant |
+| `.go` | function, type, method, constant |
+| `.rs` | function, struct, enum, trait, const |
+| `.md` (in `commands/` or `agents/`) | command, agent (by frontmatter `name:`) |
+
+For unsupported languages, emit a `skipped_languages` entry in the output
+and do not fail the run — downstream auditors will note missing coverage.
+
+## Step 2: Extract symbols
+
+Prefer heuristics over parsing.  For each supported language, grep for
+definition patterns:
+
+- TS/JS functions: `^export\s+(async\s+)?function\s+(\w+)` and
+  `^(export\s+)?(async\s+)?function\s+(\w+)`
+- TS/JS classes: `^export\s+(default\s+)?class\s+(\w+)` and
+  `^class\s+(\w+)`
+- TS/JS const exports: `^export\s+const\s+(\w+)`
+- TS types/interfaces: `^export\s+(type|interface|enum)\s+(\w+)` and
+  `^(type|interface|enum)\s+(\w+)`
+- Python: `^def\s+(\w+)`, `^class\s+(\w+)`, `^(\w+)\s*=\s*` at module level
+- Go: `^func\s+(\w+)`, `^func\s+\([^)]+\)\s+(\w+)`, `^type\s+(\w+)`,
+  `^const\s+(\w+)`
+- Rust: `^pub\s+fn\s+(\w+)`, `^fn\s+(\w+)`, `^pub\s+struct\s+(\w+)`,
+  `^pub\s+enum\s+(\w+)`, `^pub\s+trait\s+(\w+)`
+- Markdown commands/agents: read YAML frontmatter `name:` field.
+
+Use `Grep` with `-n` to capture line numbers.
+
+## Step 3: Determine visibility
+
+| Language | `exported` | `internal` |
+|---|---|---|
+| TS/JS | `export` keyword present | no `export` |
+| Python | no leading underscore | leading underscore |
+| Go | capitalized identifier | lowercase |
+| Rust | `pub` keyword | otherwise |
+
+If uncertain, set `visibility: "unknown"`.
+
+## Step 4: Emit JSON
+
+Write `${CACHE_DIR}/indexes/symbols.json`:
+
+```json
+{
+  "artifact": "symbols",
+  "run_id": "<RUN_ID>",
+  "generated_by": "docs-symbol-indexer",
+  "skipped_languages": ["<ext>", ...],
+  "symbols": [
+    {
+      "symbol": "<name>",
+      "kind": "function",
+      "file": "<relative path>",
+      "line": 42,
+      "visibility": "exported",
+      "signature": "<optional — first line of definition, whitespace-collapsed, truncated at 120 chars>"
+    }
+  ]
+}
+```
+
+Deduplicate by `(symbol, file, line)`.  Sort by `file` then `line`.
+
+## Step 5: Output
+
+Print a summary table:
+
+| Language | Symbols extracted |
+|---|---|
+| TypeScript/JavaScript | X |
+| Python | X |
+| Go | X |
+| Rust | X |
+| Markdown (commands/agents) | X |
+| **Total** | X |
+
+Confirm: `Wrote ${CACHE_DIR}/indexes/symbols.json`.

--- a/plugins/docs-steward/commands/docs-steward.md
+++ b/plugins/docs-steward/commands/docs-steward.md
@@ -1,0 +1,197 @@
+---
+name: docs-steward
+description: Audit and actively correct documentation across a repo — builds canonical indexes, runs multi-persona drift audit, edits docs, and opens a PR. Args: [repo-owner/repo-name]
+argument-hint: "[repo-owner/repo-name]"
+disable-model-invocation: true
+---
+
+# Docs Steward
+
+You are a documentation maintenance orchestrator.  You chain a fleet of agents
+to build canonical reference indexes of a repository, audit its documentation
+for drift, duplication, orphans, and onboarding gaps, actively edit the docs
+to reconcile them, re-read the corpus to verify coherence, and open a single
+PR with all changes.
+
+**Pipeline**:
+1. **Phase 0 — Index build** (7 agents in parallel): produce canonical
+   reference artifacts under `.claude/docs-cache/<run-id>/indexes/`.
+2. **Phase 1 — Drift audit** (8 agents in parallel): each auditor reads the
+   indexes + docs and emits a findings file under
+   `.claude/docs-cache/<run-id>/findings/`.
+3. **Phase 2 — Consolidation** (sequential): merge findings, resolve
+   duplication, detect conflicts.  **Checkpoint** if the consolidator
+   cannot produce a coherent plan.
+4. **Phase 3 — Editing** (sequential): apply edits on a feature branch.
+5. **Phase 4 — Manual re-read** (sequential): same manual-reader persona
+   re-reads the edited corpus.  One optional small-fix loop back to the editor.
+6. **Phase 5 — Final review + PR**: open a single PR summarizing all changes.
+
+Core tenets are defined in `references/tenets.md` of this plugin.  Every
+agent loads them at the start of its run.  The final reviewer validates
+compliance before opening the PR.
+
+## Prerequisites
+
+1. Verify GitHub CLI authentication:
+   ```
+   gh auth status
+   ```
+   If not authenticated, stop and tell the user to run `gh auth login`.
+
+2. Parse `$ARGUMENTS`:
+   - Extract `OWNER/REPO` if provided.  If not, detect from current directory:
+     `gh repo view --json nameWithOwner -q .nameWithOwner`
+   - If neither `OWNER/REPO` nor current-directory detection works, stop and
+     ask the user for the repository.
+
+3. Resolve the absolute repo working directory:
+   - If `OWNER/REPO` matches the current working directory's repo, operate
+     in place (`pwd`).
+   - Otherwise, clone to a temp path (`/tmp/docs-steward-<run-id>/<repo>`)
+     and operate there.  Record the path as `<REPO_DIR>` for downstream
+     agents.
+
+4. Generate a run ID and create the cache directory:
+   ```bash
+   RUN_ID=$(date -u +"%Y%m%dT%H%M%SZ")
+   CACHE_DIR="<REPO_DIR>/.claude/docs-cache/${RUN_ID}"
+   mkdir -p "${CACHE_DIR}/indexes" "${CACHE_DIR}/findings"
+   ```
+   Record `<RUN_ID>` and `<CACHE_DIR>` and pass them to every agent.
+
+5. Ensure `.claude/docs-cache/` is gitignored in `<REPO_DIR>`:
+   - If a root `.gitignore` exists and does not contain `.claude/docs-cache/`,
+     append the line.  If no `.gitignore` exists, create one with that line.
+
+## Phase 0: Index Build (parallel)
+
+Launch all seven index builders simultaneously in a single message with seven
+Agent tool calls.  They write to distinct files under
+`${CACHE_DIR}/indexes/` and do not share state.
+
+Pass each agent the following context in its prompt:
+- `REPO_DIR` — absolute path to the repo working directory.
+- `CACHE_DIR` — absolute path to the run's cache directory.
+- `RUN_ID`.
+- Plugin reference path: `<PLUGIN_DIR>/references/` (for `tenets.md`,
+  `index-artifact-spec.md`, etc.).
+
+Agents to launch in parallel:
+- **docs-file-cartographer** → `indexes/file-tree.md`
+- **docs-symbol-indexer** → `indexes/symbols.json`
+- **docs-route-mapper** → `indexes/routes.md`
+- **docs-config-cataloger** → `indexes/config.md`
+- **docs-inventory** → `indexes/doc-inventory.md`
+- **docs-glossary-steward** → `indexes/glossary.md`
+- **docs-history-reconciler** → `indexes/recent-changes.md`
+
+Wait for all seven to complete.  If any agent fails to write its artifact,
+stop and report which one failed.  A partial index set is not a valid basis
+for Phase 1.
+
+## Phase 1: Drift Audit (parallel)
+
+Launch all eight auditors simultaneously.  Each reads `${CACHE_DIR}/indexes/`
+and the repo's documentation, then writes its findings file to
+`${CACHE_DIR}/findings/<auditor>.md` using the shared schema from
+`references/findings-schema.md`.
+
+Agents to launch in parallel:
+- **docs-intent-auditor** → `findings/intent-auditor.md`
+- **docs-info-architect** → `findings/info-architect.md`
+- **docs-onboarding-reviewer** → `findings/onboarding-reviewer.md`
+- **docs-reference-validator** → `findings/reference-validator.md`
+- **docs-example-verifier** → `findings/example-verifier.md`
+- **docs-link-checker** → `findings/link-checker.md`
+- **docs-manual-reader** → `findings/manual-reader.md`
+- **docs-deprecation-hunter** → `findings/deprecation-hunter.md`
+
+Wait for all eight.  Proceed even if a single auditor produces zero findings
+(its file should still be written as an empty findings list) — but stop if
+an auditor fails to write a file at all.
+
+## Phase 2: Consolidation (sequential)
+
+Launch **docs-consolidator** with:
+- `CACHE_DIR`
+- `REPO_DIR`
+
+The consolidator merges all findings into
+`${CACHE_DIR}/consolidated-findings.md`, deduplicates, resolves duplication
+conflicts (tenet 6), and emits a single ordered edit plan.
+
+**Checkpoint**: if the consolidator emits
+`${CACHE_DIR}/checkpoint-required.md`, stop the pipeline and print the file
+contents to the user, asking for adjudication.  Do not proceed to Phase 3
+without explicit user direction.
+
+## Phase 3: Editing (sequential)
+
+Launch **docs-editor** with:
+- `CACHE_DIR`
+- `REPO_DIR`
+- Target branch name: `docs/steward-${RUN_ID}`
+
+The editor creates the feature branch, applies edits grouped by target file
+in the order `delete → restructure → edit`, commits one file per commit,
+and writes `${CACHE_DIR}/edits.log`.
+
+## Phase 4: Manual Re-Read (sequential)
+
+Relaunch **docs-manual-reader** with the `re-read` flag and:
+- `CACHE_DIR`
+- `REPO_DIR`
+- Reference to the prior findings file so it can compare.
+
+The re-read output is written to `${CACHE_DIR}/post-edit-findings.md`.
+
+Classify residuals per the agent's own output:
+
+- `empty` or `nits only` → proceed to Phase 5.
+- `small_local` → relaunch **docs-editor** with flag `second-pass=true` and
+  `${CACHE_DIR}/post-edit-findings.md` as the input.  This is the **only**
+  allowed re-loop.  After the second pass, proceed to Phase 5 regardless of
+  what remains — unresolved items are surfaced in the PR body.
+- `structural` → do not re-loop; carry the residuals forward into the PR body
+  under *Residual items*.
+
+## Phase 5: Final Review + PR (sequential)
+
+Launch **docs-final-reviewer** with:
+- `CACHE_DIR`
+- `REPO_DIR`
+- Branch name
+- Target repository (`OWNER/REPO`)
+
+The final reviewer inspects the branch diff, validates tenet compliance,
+assembles the PR body using `references/pr-template.md`, pushes the branch,
+and opens the PR.  PR body marker: `<!-- claude-docs-steward-v1 -->`.
+
+## Summary
+
+Print a final report:
+
+```
+## Docs Steward Summary
+
+Run ID: <RUN_ID>
+Repository: <OWNER/REPO>
+Branch: docs/steward-<RUN_ID>
+Cache: <CACHE_DIR>
+
+### Results
+- Index artifacts produced: 7
+- Auditors run: 8
+- Findings consolidated: X
+- Files edited: X
+- Deletions applied: X
+- Second edit pass triggered: <yes|no>
+- Residual items surfaced in PR: X
+
+### PR
+<PR URL>
+
+### Tenet compliance
+<pass/note summary per tenet — from the final reviewer>
+```

--- a/plugins/docs-steward/references/cache-layout.md
+++ b/plugins/docs-steward/references/cache-layout.md
@@ -1,0 +1,66 @@
+# Cache Layout
+
+The pipeline produces structured artifacts under
+`<REPO_DIR>/.claude/docs-cache/<RUN_ID>/`.  Downstream agents read
+predecessor outputs from this location rather than receiving them via
+prompt.
+
+`<RUN_ID>` is a UTC ISO-8601 timestamp with no colons: `20260421T153000Z`.
+
+## Directory structure
+
+```
+<REPO_DIR>/.claude/docs-cache/<RUN_ID>/
+├── indexes/
+│   ├── file-tree.md               # docs-file-cartographer
+│   ├── symbols.json               # docs-symbol-indexer
+│   ├── routes.md                  # docs-route-mapper
+│   ├── config.md                  # docs-config-cataloger
+│   ├── doc-inventory.md           # docs-inventory
+│   ├── glossary.md                # docs-glossary-steward
+│   └── recent-changes.md          # docs-history-reconciler
+├── findings/
+│   ├── intent-auditor.md
+│   ├── info-architect.md
+│   ├── onboarding-reviewer.md
+│   ├── reference-validator.md
+│   ├── example-verifier.md
+│   ├── link-checker.md
+│   ├── manual-reader.md
+│   └── deprecation-hunter.md
+├── consolidated-findings.md       # docs-consolidator
+├── consolidator-rejections.md     # docs-consolidator (if any records failed validation)
+├── checkpoint-required.md         # docs-consolidator (only if checkpoint fires)
+├── edits.log                      # docs-editor
+├── post-edit-findings.md          # docs-manual-reader (Phase 4)
+└── pr-body.md                     # docs-final-reviewer
+```
+
+## Gitignore
+
+The orchestrator ensures `.claude/docs-cache/` is in the repo's
+`.gitignore` before Phase 0 starts.  Cache artifacts are never committed.
+
+## Retention
+
+Old runs are not auto-deleted in v0.1.0.  The user can inspect prior
+runs in place.  A `--clean` flag to prune is out of scope.
+
+## Concurrency
+
+Only one `/docs-steward` run should be active against a given repo at a
+time.  If a prior `<RUN_ID>` directory exists without a
+`pr-body.md`, the pipeline either:
+
+- Failed mid-run (inspect `edits.log` and re-run), or
+- Is currently in a checkpoint wait (inspect `checkpoint-required.md`).
+
+The orchestrator does not lock the cache dir; avoid starting a second
+run manually while one is in flight.
+
+## Absolute vs relative paths
+
+All paths **inside** the cache are relative to `<REPO_DIR>`.  Paths
+that agents write or read to disk use absolute paths constructed from
+`<REPO_DIR>` + relative path, to avoid cwd-dependent behavior in
+subagents.

--- a/plugins/docs-steward/references/checkpoint-criteria.md
+++ b/plugins/docs-steward/references/checkpoint-criteria.md
@@ -1,0 +1,89 @@
+# Checkpoint Criteria
+
+The `docs-consolidator` pauses the pipeline when it cannot produce a
+coherent edit plan.  When any of the triggers below fire, the consolidator
+writes `${CACHE_DIR}/checkpoint-required.md` and exits without writing
+`consolidated-findings.md`.  The orchestrator then stops Phase 3 and
+surfaces the file to the user.
+
+## Triggers
+
+### 1. Conflict density
+
+More than **20%** of findings have at least one direct conflict with
+another finding targeting the same file + location.
+
+A direct conflict is two findings with `action: edit` (or one `edit` and
+one `delete`) on the same `location.file` + overlapping line range, whose
+`suggested_edit` values are mutually exclusive.
+
+### 2. Structural incoherence
+
+The consolidator cannot place content into a coherent information
+architecture.  Signals:
+
+- Tenet-6 resolution has three or more candidate canonical homes for the
+  same content and no clear winner by depth-specificity heuristic.
+- Section READMEs that the `docs-info-architect` flagged as structurally
+  inconsistent with no majority pattern to normalize toward.
+
+### 3. Production config deletion
+
+Any `action: delete` finding targeting a file the consolidator classifies
+as a production config (file path matches `*production*`, `*prod*`,
+`config/prod/**`, or the file contains a `NODE_ENV=production`-style
+pragma).  The severity is raised to `critical` and the user adjudicates
+before the editor runs.
+
+### 4. Secret-adjacent deletions
+
+Any `action: delete` finding whose target key name matches `*_SECRET`,
+`*_TOKEN`, `*_PASSWORD`, `*_KEY`, or `*_CREDENTIAL` (case-insensitive),
+even if the deprecation-hunter believes the key is unreferenced.  Never
+auto-delete these; always escalate.
+
+### 5. Large-scale deletion
+
+The total `action: delete` count exceeds **50** records, or any single
+file would be reduced to under 20% of its current size.  Mass deletions
+are typically signs of a misfire in the deprecation-hunter (e.g. missed
+references in a language the symbol indexer does not cover).
+
+## Checkpoint file format
+
+`${CACHE_DIR}/checkpoint-required.md`:
+
+```markdown
+# Docs Steward Checkpoint — Adjudication Required
+
+**Run ID:** <RUN_ID>
+**Trigger(s):** <list of triggers from above>
+
+## What the consolidator saw
+
+<one paragraph, plain language>
+
+## Options
+
+1. **Adjudicate and resume** — resolve the conflicts below, edit
+   `consolidated-findings.md` by hand, then re-run with `--resume
+   <RUN_ID>`.
+2. **Abort** — delete `${CACHE_DIR}` and re-run from scratch, possibly
+   with narrower scope.
+
+## Conflicts / issues to resolve
+
+<numbered list with finding IDs, file paths, and short descriptions>
+```
+
+## Orchestrator behavior on checkpoint
+
+The orchestrator:
+
+1. Reads and prints the full checkpoint file to the user.
+2. Stops without creating a branch or making any edits.
+3. Leaves `${CACHE_DIR}` in place for inspection and manual adjudication.
+4. Exits with a non-zero status code so scheduled runs surface as failed.
+
+Resumption (the `--resume` flag) is out of scope for v0.1.0; after
+adjudication, re-run the pipeline with the same arguments.

--- a/plugins/docs-steward/references/findings-schema.md
+++ b/plugins/docs-steward/references/findings-schema.md
@@ -1,0 +1,95 @@
+# Findings Schema
+
+All Phase 1 auditors emit findings using the same schema.  The consolidator
+merges across auditor files by this schema, so deviating breaks the pipeline.
+
+## Per-finding record
+
+Each finding is a single record in the auditor's findings file:
+
+```yaml
+- id: <AUDITOR>-<SHORT_HASH>          # e.g. intent-auditor-a3f91c
+  auditor: <auditor-name>             # e.g. docs-intent-auditor
+  severity: <critical|major|minor|nit>
+  action: <edit|delete|restructure>
+  location:
+    file: <relative path from repo root>
+    line_start: <int|null>
+    line_end: <int|null>
+    anchor: <heading text or markdown anchor, if applicable>
+  claim: |
+    <what the doc currently says — verbatim or faithful paraphrase>
+  reality: |
+    <what the code/index/history actually shows — with file:line references>
+  suggested_edit: |
+    <concrete edit proposal.  For action=delete, the lines/section to remove.
+     For action=restructure, the source and destination.  For action=edit,
+     a before/after or a clear replacement.>
+  tenet_refs: [<int>, ...]            # tenets invoked, e.g. [1, 6]
+```
+
+## File layout
+
+Each auditor writes a single markdown file with YAML front matter plus
+records.  Format:
+
+```markdown
+---
+auditor: <auditor-name>
+run_id: <RUN_ID>
+finding_count: <int>
+---
+
+# <Auditor Display Name> — Findings
+
+## Summary
+<one paragraph, what the auditor looked at + headline counts>
+
+## Findings
+
+```yaml
+- id: ...
+  # ...
+```
+
+If an auditor has zero findings, write the file with `finding_count: 0`, a
+short summary explaining why nothing was flagged, and an empty
+`## Findings` section.  **Do not skip writing the file** — the consolidator
+uses the file's existence as proof the auditor ran.
+
+## Severity
+
+| Level | Meaning |
+|---|---|
+| critical | Doc is actively misleading; a reader following it would make a wrong change or break something |
+| major | Significant drift: wrong signature, wrong command, missing required step |
+| minor | Cosmetic inconsistency, slightly outdated wording, small ordering issue |
+| nit | Style-only: voice, tone, punctuation preference |
+
+## Action
+
+| Value | Meaning |
+|---|---|
+| edit | Rewrite the claim to match reality |
+| delete | Remove deprecated/orphan content entirely (tenet 5) |
+| restructure | Move content to its canonical home and replace duplicates with links (tenet 6) |
+
+## Severity + action interaction (editor order)
+
+The editor processes in this order per target file:
+
+1. All `action: delete` findings.
+2. All `action: restructure` findings.
+3. All `action: edit` findings.
+
+Within each action bucket, `critical > major > minor > nit`.
+
+## Validation
+
+- `id` must be unique within the file.
+- `location.file` must be a real path under `REPO_DIR`.
+- `suggested_edit` must be non-empty.
+- `tenet_refs` must be a non-empty list of ints in `1..7`.
+
+The consolidator rejects any record that fails validation and lists
+rejections in `${CACHE_DIR}/consolidator-rejections.md`.

--- a/plugins/docs-steward/references/index-artifact-spec.md
+++ b/plugins/docs-steward/references/index-artifact-spec.md
@@ -1,0 +1,134 @@
+# Index Artifact Spec
+
+Phase 0 agents emit canonical reference artifacts under
+`${CACHE_DIR}/indexes/`.  Phase 1 auditors read these files rather than
+re-crawling the repo.  This file is the contract between the two phases.
+
+## file-tree.md
+
+Emitted by `docs-file-cartographer`.
+
+Markdown.  A hierarchical tree with one entry per file or directory plus a
+one-line purpose:
+
+```markdown
+# File Tree
+
+## Top-level
+
+- `/README.md` — Root entry point; marketplace overview + install
+- `/CLAUDE.md` — Repo guidance for AI contributors
+- `/plugins/` — Individual plugin directories
+  - `/plugins/feature-creator/` — Feature development pipeline plugin
+    - `/plugins/feature-creator/README.md` — User-facing plugin docs
+    - `/plugins/feature-creator/commands/` — Slash command definitions
+    - ...
+```
+
+Excludes: `.git/`, `node_modules/`, `.claude/docs-cache/`, common build
+output paths (`dist/`, `build/`, `target/`, `.next/`, `.venv/`).
+
+## symbols.json
+
+Emitted by `docs-symbol-indexer`.
+
+JSON.  Array of symbol records:
+
+```json
+[
+  {
+    "symbol": "renderIssue",
+    "kind": "function",
+    "file": "plugins/feature-creator/agents/feature-planner.md",
+    "line": 42,
+    "visibility": "exported",
+    "signature": "renderIssue(issue: Issue): string"
+  }
+]
+```
+
+`kind`: `function | class | method | constant | type | interface | enum | macro`.
+`visibility`: `exported | internal | unknown`.
+Repo-wide deduplication by `(symbol, file, line)`.
+
+## routes.md
+
+Emitted by `docs-route-mapper`.
+
+Markdown table(s) listing public interfaces.  Separate sections for each
+interface kind found in the repo:
+
+- HTTP routes: method, path, handler file:line, middleware chain (if
+  detectable).
+- CLI commands / slash commands: name, definition file:line, brief
+  description.
+- Public SDK/library exports: package entry point, named exports.
+
+If no public surface is found for a category, omit that section and state
+so in a `## Coverage` footer.
+
+## config.md
+
+Emitted by `docs-config-cataloger`.
+
+Markdown sections per config source:
+
+- `## Environment Variables` — every env var referenced in the code, with
+  file:line of first reference, default value (if any), and a flag for
+  whether it appears in `.env*` example files.
+- `## Config Files` — each config file (`*.config.*`, `config.toml`,
+  `settings.json`, etc.), its keys, and which files read those keys.
+- `## Schemas` — database schemas, JSON schemas, OpenAPI specs with paths.
+
+Mark every key with a `referenced: <yes|no>` field — the
+`docs-deprecation-hunter` uses this directly to flag orphans.
+
+## doc-inventory.md
+
+Emitted by `docs-inventory`.
+
+Markdown.  One entry per doc file with:
+- Path
+- Stated purpose (from the file's own opening)
+- Top-level headings
+- A short summary of the claims the doc makes (technical assertions a
+  reader would rely on)
+
+Covers: `README.md` (all levels), `CLAUDE.md`, `docs/**`, `/docs/**`,
+`.github/**/*.md` user-facing docs, `CHANGELOG.md`.
+
+## glossary.md
+
+Emitted by `docs-glossary-steward`.
+
+Markdown.  Alphabetized canonical definitions:
+
+```markdown
+## Marketplace
+A catalog of plugins installable together via `/plugin marketplace add`.
+**First defined in:** `README.md`
+**Alternate forms seen:** "plugin marketplace", "the marketplace"
+```
+
+Includes acronyms, product terms, internal jargon.  Each entry notes the
+canonical source and any inconsistent variants.
+
+## recent-changes.md
+
+Emitted by `docs-history-reconciler`.
+
+Markdown.  Grouped summary of the last 90 days of git history (or repo
+lifetime if shorter), partitioned by area:
+
+```markdown
+## plugins/feature-creator (last 90 days)
+
+- 2026-04-05: v0.2.0 release — four new skills (planner, reviewer, etc.)
+- 2026-04-18: marketplace install fix (PR #9)
+- ...
+
+**Likely doc impact:** `plugins/feature-creator/README.md`, root README plugin table
+```
+
+Each section ends with a `Likely doc impact:` list so auditors can
+prioritize.

--- a/plugins/docs-steward/references/manual-reader-protocol.md
+++ b/plugins/docs-steward/references/manual-reader-protocol.md
@@ -1,0 +1,87 @@
+# Manual Reader Protocol
+
+Used by `docs-manual-reader` in Phase 1 (initial read) and Phase 4
+(post-edit re-read).  Same agent definition, same protocol — the
+difference is only the input corpus (pre-edit vs post-edit).
+
+## Reading order
+
+1. Start at `/README.md`.
+2. Note every link in the root README.  Queue them.
+3. Visit each linked doc in the order encountered.  For each:
+   - Read it as if you had just landed on it from the root.
+   - Note new links encountered.
+   - Queue any links not already visited.
+4. Continue until the queue is empty or all visited docs have been read.
+5. Visit any docs that were **not** reachable from the root but exist in
+   `doc-inventory.md`.  These are orphans by definition — flag them.
+
+Do not skip around.  Read in the order a user would reach them.
+
+## What to look for
+
+### Tenet 1 — User-facing READMEs
+
+- Is the opening scannable?
+- Does the reader know "what is this?" after the first paragraph?
+- Are there dense reference details that belong in backing docs?
+
+### Tenet 2 — Root as entry point
+
+- Does the root README orient a first-time reader?
+- Are the links from root → section READMEs descriptive?
+- Does each linked doc lead somewhere useful?
+
+### Tenet 3 — Coherent narrative
+
+- Does the reading sequence build on itself, or does it require jumping
+  back?
+- Are there contradictions between sibling docs?
+- Do terms get defined before being used?
+
+### Tenet 4 — Section README consistency
+
+- When reading sibling section READMEs in sequence, do they feel like
+  members of the same family, or like different products?
+- Do they share headings and detail levels?
+
+### Tenet 6 — No duplication
+
+- Does the same explanation appear in two places?
+- Is install covered in three READMEs?
+- Does a table in one doc repeat content from another?
+
+## Output
+
+Write to `${CACHE_DIR}/findings/manual-reader.md` (Phase 1) or
+`${CACHE_DIR}/post-edit-findings.md` (Phase 4), using the shared schema
+from `findings-schema.md`, plus a top-level section:
+
+```markdown
+## Overall classification (Phase 4 only)
+
+classification: <empty | nits_only | small_local | structural>
+
+reasoning: <one paragraph>
+```
+
+Classification semantics (Phase 4):
+
+| Value | Meaning | Orchestrator action |
+|---|---|---|
+| `empty` | No findings | Skip second pass, proceed to PR |
+| `nits_only` | Only `severity: nit` findings | Skip second pass, proceed |
+| `small_local` | ≤10 findings, all `severity: minor` or below, all within existing docs | One second-pass edit allowed |
+| `structural` | Any `severity: major` or above, OR findings requiring new docs or moved sections | No second pass; surface in PR body |
+
+## Re-read specifics (Phase 4)
+
+In Phase 4, the agent receives a reference to its Phase 1 findings file
+(`${CACHE_DIR}/findings/manual-reader.md`) and the editor's edit log
+(`${CACHE_DIR}/edits.log`).  Use these to:
+
+- Confirm Phase 1 findings were addressed (don't re-flag items already
+  resolved).
+- Focus attention on docs the editor touched.
+- Check for new issues introduced by the edits (broken cross-refs, new
+  duplications, split narratives).

--- a/plugins/docs-steward/references/pr-template.md
+++ b/plugins/docs-steward/references/pr-template.md
@@ -1,0 +1,83 @@
+# PR Template
+
+Used by `docs-final-reviewer` to compose the PR body.  Written to
+`${CACHE_DIR}/pr-body.md` and passed to `gh pr create` via `--body-file`
+(shell-safety rule).
+
+## Title
+
+```
+docs: steward <RUN_ID>
+```
+
+Under 70 characters.  Details go in the body.
+
+## Body
+
+```markdown
+<!-- claude-docs-steward-v1 -->
+
+## Summary
+
+Docs-steward reconciled documentation against the code on
+<RUN_ID>.  <N> docs were edited, <D> deprecated/orphan items were
+removed, and <R> restructures consolidated duplicated content.
+
+## Findings applied
+
+### Deletions (tenet 5)
+- `<file>:<anchor>` — <short description> (finding `<id>`) — commit `<sha>`
+- ...
+
+### Restructures (tenet 6)
+- `<from>` → `<to>` — <short description> (finding `<id>`) — commit `<sha>`
+- ...
+
+### Edits
+- `<file>:<anchor>` — <short description> (finding `<id>`) — commit `<sha>`
+- ...
+
+## Residual items
+
+<Items from Phase 4 that were not auto-resolved.  Grouped by severity.
+If none: "None — the manual re-read passed cleanly.">
+
+## Tenet compliance
+
+- [x] 1. READMEs are user-facing
+- [x] 2. Root README is the entry point
+- [x] 3. Corpus reads as a manual (verified by post-edit re-read)
+- [x] 4. Section READMEs are consistent
+- [x] 5. Deprecated/orphaned content removed, not annotated
+- [x] 6. No duplication
+- [x] 7. Post-edit re-read performed
+
+<Any unchecked items must have a one-line note explaining why.>
+
+## How to review
+
+1. Start from the root `README.md` and follow links — the PR should read
+   as a coherent manual.
+2. Inspect deletions first (`git log --diff-filter=D` on the branch) —
+   these are the highest-impact changes.
+3. Spot-check a few edits against the cache's indexes:
+   `<CACHE_DIR>/indexes/`.
+
+## Plan of action
+
+- Human review of all sections above.
+- Merge when satisfied; or push additional edits to the branch before
+  merging.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+## Content rules
+
+- No emoji in the narrative text (the `🤖` trailer is acceptable as a
+  generated-marker convention).
+- Finding IDs are the ones from the shared schema; they let reviewers
+  trace each edit back to its auditor.
+- Commit SHAs use the short form (7 characters).
+- If a section would be empty (e.g. no deletions), omit the section
+  header entirely rather than leaving an empty heading.

--- a/plugins/docs-steward/references/readme-style-guide.md
+++ b/plugins/docs-steward/references/readme-style-guide.md
@@ -1,0 +1,86 @@
+# README Style Guide
+
+Applies to every `README.md` in the repo.  Enforced by `docs-info-architect`
+and `docs-manual-reader`; applied by `docs-editor`.
+
+## Tenets invoked
+
+1 (user-facing), 2 (root is entry point), 4 (section consistency), 6 (no
+duplication).
+
+## Structure
+
+A README should have, in order, the components that apply:
+
+1. **Title** — H1, matches the directory or project name.
+2. **One-paragraph overview** — what this is, in plain language, answers
+   "what is this for?" in one breath.
+3. **Quick Start** or **Installation** — copy-pasteable commands for the
+   most common path.
+4. **Usage** — the one or two most common invocations, with minimal context.
+5. **Architecture / Components** (when there are multiple parts) — a short
+   table or list linking to each component.
+6. **Prerequisites** (when non-obvious) — tools, auth, env vars needed.
+7. **Contributing / Development** (at root only, or where meaningful at a
+   section) — links out to a dedicated `CONTRIBUTING.md` or `CLAUDE.md`
+   rather than inlining.
+8. **License** (at root only).
+
+Section READMEs (e.g. under `plugins/<name>/`) use the same ordering but
+omit Overview-of-the-whole-repo framing and global install steps; they
+assume the reader has already landed via the root.
+
+## Voice
+
+- **Scannable**: bullets and tables for facts; paragraphs for concepts only.
+- **Direct**: "Run X to do Y."  Not "You might want to run X so that Y can
+  happen."
+- **Link out for depth**: one sentence in the README, link to the full
+  reference doc.
+- **No marketing**: no emoji, exclamation points, or superlatives unless
+  the repo's existing voice already uses them.
+- **Code blocks are copy-pasteable**: assume the reader will run them
+  verbatim.
+
+## Length targets (soft)
+
+| README | Target length |
+|---|---|
+| Root | 100–300 lines |
+| Section (plugin/module) | 50–300 lines |
+| Subsection | <100 lines — if longer, probably belongs in a backing doc |
+
+These are soft targets.  The editor does not cut content solely for length,
+but a README running 500+ lines is a strong signal content should move to
+backing docs with links.
+
+## What does NOT belong in a README
+
+- Full API reference (goes in `docs/api.md` or generated output).
+- Full architecture description (goes in `docs/architecture.md` or
+  `CLAUDE.md`).
+- Exhaustive config-key catalog (goes in `docs/configuration.md`).
+- History or changelog detail (goes in `CHANGELOG.md`).
+- Internal implementation notes (goes in `CLAUDE.md` or inline comments).
+
+When the docs-editor finds such content in a README, it restructures
+(tenet 6): moves the content to its canonical backing doc, leaves a link.
+
+## What a good link looks like
+
+- **Bad:** `See the contribution guide for more details.`
+- **Good:** `See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add a
+  plugin.` — use actual link, name the target, state what the reader will
+  find there.
+
+## Section README consistency (tenet 4)
+
+Section READMEs under a common parent (e.g. every plugin's README) should:
+
+- Open with the same kind of one-paragraph description.
+- Have the same top-level headings where applicable.
+- Use the same table format for components (if they have components).
+- Link back to the root README in roughly the same way.
+
+When sibling READMEs drift in structure, the `docs-info-architect` flags it
+and the editor normalizes the weaker ones toward the strongest.

--- a/plugins/docs-steward/references/tenets.md
+++ b/plugins/docs-steward/references/tenets.md
@@ -1,0 +1,85 @@
+# Core Tenets
+
+Every agent in the docs-steward pipeline loads this file at the start of its
+run.  These are non-negotiable.  The consolidator and final-reviewer validate
+compliance before the PR opens.
+
+## 1. READMEs are user-facing
+
+READMEs are written for fast scanning by a real human landing on a repo or
+directory for the first time.  They are **not** reference dumps.  Dense
+reference detail lives in backing docs (architecture, API reference,
+contribution guide, etc.) and is linked from the README.
+
+**Heuristics:**
+- Opening paragraph answers "what is this?" in one breath.
+- Installation / quick-start within the first screen.
+- Tables and bullets over paragraphs for scannable facts.
+- Link out to deeper docs rather than inlining details.
+
+## 2. Root README is the entry point
+
+A reasonable first-time user should be able to start at `/README.md` and get
+coherent ongoing context — understanding structure, installation, usage, and
+how to contribute — by following links only.  No required knowledge is
+assumed beyond the repo's stated audience.
+
+**Heuristics:**
+- Every directory a user is expected to understand has a linked entry from
+  the root.
+- No dead ends: every linked doc leads somewhere useful.
+- The reading path from root → every other doc is traceable.
+
+## 3. The corpus must read as a manual
+
+At least one persona (the `docs-manual-reader`) walks the docs like a human
+user, starting at the root README, following links, and treating the whole
+body as a single linear manual.  This exercise is the ground-truth test of
+coherence.  The same persona re-reads after edits.
+
+## 4. Section READMEs are consistent
+
+Section-level READMEs (e.g., `plugins/<name>/README.md`) share the same
+top-level components where applicable:
+
+1. Overview / what this is
+2. Installation or activation (if applicable)
+3. Usage / quick start
+4. Architecture or components table
+5. Contribution or development notes (if applicable)
+6. Links to backing docs
+
+Level of detail is comparable across peers.  One section README should not
+be ten times the size of its sibling for an equivalent surface area.
+
+## 5. Deprecated/orphaned content is removed, not annotated
+
+Stale variables, config keys, env keys, commands, and doc references are
+deleted.  Do not leave behind `// deprecated` markers, "legacy" sections, or
+notes saying "this used to be..."  The git history is the record.
+
+**Exceptions (flag but do not delete automatically):**
+- Anything named `*_SECRET`, `*_TOKEN`, `*_PASSWORD`, `*_KEY`.
+- Items in production config files (the consolidator raises severity and
+  triggers a checkpoint).
+
+## 6. No duplication
+
+Information lives in exactly one canonical place.  Everywhere else, link to
+it.  When duplicate content is detected, the consolidator picks the
+canonical home (deepest-specific doc wins; README links out).
+
+## 7. Post-edit re-read
+
+After the first edit pass, the manual-reader re-reads the entire corpus from
+the root README.  Residual issues either:
+
+- Trigger a second (and only a second) edit pass for small/local fixes.
+- Surface in the PR body for human review if they are structural.
+
+## Voice
+
+Preserve the existing voice unless a finding explicitly requires rewriting.
+When in doubt, err toward the style of the root README.  Do not introduce
+emoji, exclamation points, or marketing tone unless those already exist in
+the target doc.

--- a/plugins/docs-steward/references/voice-guide.md
+++ b/plugins/docs-steward/references/voice-guide.md
@@ -1,0 +1,57 @@
+# Voice Guide
+
+Applied by `docs-editor` when rewriting content.
+
+## Rule of least surprise
+
+Match the voice already present in the target doc.  Changing a doc's voice
+is not a drift-fix — it is a rewrite, and is only warranted if a finding
+explicitly calls for it with `action: restructure` and a tenet reference.
+
+## When inferring voice from the existing corpus
+
+Sample voice from the root README first, then the nearest sibling docs.
+If these disagree, pick the majority voice across the repo's user-facing
+docs (not internal `CLAUDE.md`).
+
+## Defaults when the doc is essentially empty
+
+Fall back to:
+
+- Second person neutral ("You can run...", "Run...").
+- Active voice.
+- Present tense.
+- No emoji.
+- No exclamation points.
+- Sentence case for headings unless the repo has established title case.
+- Code blocks in fenced triple-backtick with language hint where known.
+
+## Preserving intent during edits
+
+A drift edit replaces incorrect content with correct content.  It does
+**not**:
+
+- Reword correct-but-stylistically-imperfect prose.
+- Rearrange sections unless the finding calls for `action: restructure`.
+- Add meta-commentary ("This section has been updated...").
+- Add dates, authors, or change markers — git history is the record.
+
+## Deletion over annotation
+
+Per tenet 5, when content is stale, delete it.  Do not leave:
+
+- "Deprecated: ..."  markers.
+- "Note: this used to ..."  sidebars.
+- Commented-out sections.
+
+The exception is when the finding explicitly marks `action: edit` and the
+edit requires noting a transition for the reader — in which case the
+transition note is brief and in the same voice as the rest of the doc.
+
+## Links
+
+- Use relative paths for intra-repo links: `[text](path/to/file.md)`.
+- Use full URLs for external links, with descriptive anchor text.
+- Never link to line numbers that are likely to drift (prefer section
+  anchors).  Exception: `CLAUDE.md` reference tables where line numbers
+  are inspected by agents.


### PR DESCRIPTION
## Summary

New plugin `docs-steward` (v0.1.0) — a six-phase pipeline that actively reconciles documentation against deployed code:

- **Phase 0 — Indexes**: 7 parallel agents build canonical reference artifacts (file tree, symbols, routes, config, doc inventory, glossary, recent-changes) under `.claude/docs-cache/<run-id>/`.
- **Phase 1 — Audit**: 8 parallel critic personas emit findings against the indexes + docs.
- **Phase 2 — Consolidate**: merge findings, resolve duplication, emit edit plan or trigger a checkpoint.
- **Phase 3 — Edit**: apply the plan on a feature branch, one commit per doc file, deletions → restructures → edits.
- **Phase 4 — Re-read**: the manual-reader persona walks the edited corpus; one small-fix loop allowed.
- **Phase 5 — PR**: tenet-compliance check, single PR with residuals surfaced.

Seven core tenets are loaded by every agent and validated by the final reviewer: user-facing READMEs, root as entry point, corpus reads as a manual, section-README consistency, deletion over annotation, no duplication, post-edit re-read.

Also corrects the security-scanner version in the root README (0.3.0 → 0.4.0).

## Files

- New plugin: `plugins/docs-steward/` (1 command, 18 agents, 9 references, README)
- Updated: `.claude-plugin/marketplace.json` (new entry, v0.1.0), `README.md`, `CLAUDE.md`

## Test plan

- [ ] `/plugin marketplace add .` from a local clone and confirm `/docs-steward` appears in the slash-command menu
- [ ] Dry-run `/docs-steward` against this repo; verify indexes populate under `.claude/docs-cache/`, findings files are produced, consolidator output is coherent, and the pipeline opens a PR
- [ ] Verify version lockstep: `plugins/docs-steward/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` both show `0.1.0`
- [ ] Confirm `.claude/docs-cache/` is never committed (root `.gitignore` already excludes `.claude/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
