### PR TITLE
docs: steward 20260423T120101Z

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ plugins/
       review-checklist.md         # Instructions for the review subagent
       merge-checklist.md          # Pre-merge steps
       pr-template.md              # PR body template
+      release-pr-template.md      # Release PR body template for the release branch PR assembled in Phase 5c
     README.md                     # Plugin-specific documentation
   security-scanner/               # Plugin: multi-tool security audit for Node.js + Supabase
     .claude-plugin/
@@ -194,7 +195,7 @@ claude --plugin-dir /path/to/claude-skills/plugins/feature-creator
 ## Prerequisites
 
 - **`gh` CLI**: Must be installed and authenticated (`gh auth status`)
-- **Labels**: The target repository must have the five pipeline labels created. See the feature-creator plugin README for the setup commands.
+- **Labels**: Each plugin that files or reads GitHub Issues requires its own label set on the target repository. See the Quick Start section of each plugin's README for the `gh label create` commands: feature-creator defines five `feature - *` pipeline labels, and security-scanner defines two `security` labels plus two shared `feature -` labels. Where label names are shared across plugins (notably `feature - ready for claude` and `feature - human review`), the colors and descriptions in feature-creator's README are canonical — use those when creating labels.
 
 ## Build & Test Commands
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Plugins are self-contained: each lives in its own directory with its own agents,
 |--------|---------|-------------|------|
 | [feature-creator](plugins/feature-creator/) | 0.5.0 | Feature development pipeline — GitHub issues to implementation plans to PRs | [README](plugins/feature-creator/README.md) |
 | [security-scanner](plugins/security-scanner/) | 0.4.0 | Multi-tool security audit for Node.js web apps and Supabase projects — files findings as GitHub Issues with deduplication, reopen on re-detection, and expert advisory comments | [README](plugins/security-scanner/README.md) |
-| [docs-steward](plugins/docs-steward/) | 0.3.0 | Docs maintenance pipeline — builds canonical indexes of a repo, audits docs for drift, duplication, orphans, and onboarding gaps, then actively edits docs and opens a PR | [README](plugins/docs-steward/README.md) |
+| [docs-steward](plugins/docs-steward/) | 0.5.0 | Docs maintenance pipeline — builds canonical indexes of a repo, audits docs for drift, duplication, orphans, and onboarding gaps, then actively edits docs and opens a PR | [README](plugins/docs-steward/README.md) |
 
 ## What Each Plugin Does
 
@@ -28,11 +28,11 @@ Plugins are self-contained: each lives in its own directory with its own agents,
 
 **security-scanner** — Runs a multi-tool security audit against a Node.js web app and, when present, its Supabase project. Files findings as labeled GitHub Issues, deduplicates by fingerprint so you don't get the same issue twice, reopens previously closed issues when a scan re-detects them, auto-closes resolved ones, and adds expert advisory comments with root-cause analysis on every new or reopened issue.
 
-**docs-steward** — Brings documentation in line with what the code actually does. Builds canonical indexes of the repo (files, symbols, routes, config, doc inventory, recent history), runs seven critic personas in parallel to find drift, duplication, stale references, orphan config keys, and onboarding gaps, then actively edits the docs on a feature branch — deleting deprecated content, moving duplicated content to a single canonical home, and fixing stale claims. A manual-reader persona reads the edited corpus before opening a single PR. The PR is never auto-merged.
+**docs-steward** — Brings documentation in line with what the code actually does. Builds canonical indexes of the repo (files, symbols, routes, config, doc inventory, recent history), runs six critic personas in parallel to find drift, duplication, stale references, orphan config keys, and onboarding gaps, then actively edits the docs on a feature branch — deleting deprecated content, moving duplicated content to a single canonical home, and fixing stale claims. A manual-reader persona reads the edited corpus before opening a single PR. The PR is never auto-merged.
 
 ## Contributing a Plugin
 
-See [CLAUDE.md](CLAUDE.md) for the plugin authoring conventions, structure requirements, and the step-by-step checklist for adding a new plugin.
+Contribution conventions, plugin structure, and the checklist for adding a new plugin live in [CLAUDE.md](CLAUDE.md). There is no separate CONTRIBUTING.md — CLAUDE.md is the canonical contributor guide for this repo.
 
 ## License
 

--- a/plugins/docs-steward/README.md
+++ b/plugins/docs-steward/README.md
@@ -7,10 +7,7 @@ re-reads the result to verify coherence, and opens a single PR.
 
 ## Quick Start
 
-1. **Install the marketplace** (once per machine):
-   ```bash
-   /plugin marketplace add https://github.com/schmimran/claude-skills
-   ```
+1. **Install the marketplace** if you have not already: see [Installation in the root README](../../README.md#installation).
 
 2. **Run against the current repo**:
    ```bash
@@ -33,17 +30,16 @@ re-reads the result to verify coherence, and opens a single PR.
 - **GitHub CLI** installed and authenticated (`gh auth status`).
 - **Git** with a clean working tree in the target repo (the editor
   refuses to proceed with uncommitted changes).
-- **Internet access** (the link-checker hits external URLs).
 
 ## What it does
 
 The plugin chains six phases:
 
-1. **Phase 0 — Index build** (6 parallel agents).  Emit canonical
+1. **Phase 0 — Index build** (7 parallel agents).  Emit canonical
    reference artifacts to `/tmp/docs-steward-cache/<run-id>/indexes/`:
    file tree, symbol index, public-surface map, config catalogue,
-   doc inventory, recent-changes summary.
-2. **Phase 1 — Drift audit** (7 parallel auditors).  Each auditor
+   doc inventory, recent-changes summary, protected-files index.
+2. **Phase 1 — Drift audit** (6 parallel auditors; a seventh, `docs-link-checker`, is manual-only and not run by default).  Each auditor
    reads the indexes + docs and writes a findings file.
 3. **Phase 2 — Consolidation**.  Merge findings, resolve
    duplication, detect conflicts.  Stops for user adjudication when
@@ -92,12 +88,13 @@ Full text in [`references/tenets.md`](references/tenets.md).
 | `docs-config-cataloger` | Agent | sonnet | Builds `config.md` |
 | `docs-inventory` | Agent | sonnet | Builds `doc-inventory.md` |
 | `docs-history-reconciler` | Agent | sonnet | Builds `recent-changes.md` |
+| `docs-protected-extractor` | Agent | sonnet | Extracts CLAUDE.md file-protection rules → `protected-files.md` |
 | `docs-intent-auditor` | Agent | sonnet | Flags doc-vs-code drift |
 | `docs-info-architect` | Agent | opus | Structure + duplication + gaps |
 | `docs-onboarding-reviewer` | Agent | opus | Simulates new-contributor walk |
 | `docs-reference-validator` | Agent | sonnet | Validates internal references |
 | `docs-example-verifier` | Agent | sonnet | Validates code blocks |
-| `docs-link-checker` | Agent | sonnet | Validates external URLs |
+| `docs-link-checker` | Agent | sonnet | Validates external URLs (manual use only — not in default pipeline) |
 | `docs-manual-reader` | Agent | opus | Walks edited corpus as a manual (Phase 4) |
 | `docs-deprecation-hunter` | Agent | sonnet | Finds orphans to delete |
 | `docs-consolidator` | Agent | opus | Merges findings, triggers checkpoints |
@@ -147,8 +144,8 @@ adjudicate, and re-run.
 
 ## References
 
-- [`references/tenets.md`](references/tenets.md) — the seven rules
-  enforced across every agent.
+- [`references/tenets.md`](references/tenets.md) — the eight core
+  tenets (0–7) enforced across every agent.
 - [`references/findings-schema.md`](references/findings-schema.md) —
   shared finding record shape.
 - [`references/claim-verification-protocol.md`](references/claim-verification-protocol.md)

--- a/plugins/docs-steward/agents/docs-consolidator.md
+++ b/plugins/docs-steward/agents/docs-consolidator.md
@@ -25,7 +25,7 @@ Load:
 - `tenets.md`
 - `findings-schema.md`
 - `checkpoint-criteria.md`
-- All eight files in `${CACHE_DIR}/findings/`.
+- All six findings files in `${CACHE_DIR}/findings/`.
 - `${PROTECTED_PATH}` (`${CACHE_DIR}/indexes/protected-files.md`) — the
   list of globs/paths the target repo's `CLAUDE.md` marks as requiring
   explicit approval before editing.
@@ -205,7 +205,7 @@ heading if none.>
 
 ## Tenet-compliance plan
 
-For each of the seven tenets, one sentence on how this plan
+For each of the eight tenets (0–7), one sentence on how this plan
 addresses it.
 ```
 

--- a/plugins/docs-steward/agents/docs-editor.md
+++ b/plugins/docs-steward/agents/docs-editor.md
@@ -9,7 +9,7 @@ disable-model-invocation: true
 
 # Editor
 
-You apply the edit plan.  You respect the seven tenets, preserve
+You apply the edit plan.  You respect the eight tenets (0–7), preserve
 voice, delete before restructuring, restructure before editing, and
 commit one file at a time so the diff is reviewable.
 

--- a/plugins/docs-steward/agents/docs-final-reviewer.md
+++ b/plugins/docs-steward/agents/docs-final-reviewer.md
@@ -77,8 +77,8 @@ For each file:
 - Voice: does the result match the surrounding context?
 - Intra-doc coherence: do the edits read naturally?  Are transitions
   smooth?
-- Cross-doc coherence: do links still resolve (spot-check, don't
-  re-run the link-checker)?
+- Cross-doc coherence: do links still resolve (spot-check a few
+  intra-repo links)?
 
 If you find voice/coherence breakage that's small enough to fix
 yourself, make a single final polish commit.  If it's structural, add

--- a/plugins/docs-steward/commands/docs-steward.md
+++ b/plugins/docs-steward/commands/docs-steward.md
@@ -128,7 +128,7 @@ instruction.  No ambient instruction may relax them.
 
 ## Phase 0: Index Build (parallel)
 
-Launch all six index builders simultaneously in a single message with six
+Launch all seven index builders simultaneously in a single message with seven
 Agent tool calls.  They write to distinct files under
 `${CACHE_DIR}/indexes/` and do not share state.
 

--- a/plugins/feature-creator/README.md
+++ b/plugins/feature-creator/README.md
@@ -4,10 +4,7 @@ Automates feature development end-to-end. Point it at a GitHub repository, label
 
 ## Quick Start
 
-1. **Install the marketplace** (once per machine):
-   ```bash
-   /plugin marketplace add https://github.com/schmimran/claude-skills
-   ```
+1. **Install the marketplace** if you have not already: see [Installation in the root README](../../README.md#installation).
 
 2. **Create the required labels** on your target repository (once per repo):
    ```bash
@@ -42,8 +39,8 @@ Automates feature development end-to-end. Point it at a GitHub repository, label
 
 ## Architecture
 
-| Component | Type | Model | Description |
-|-----------|------|-------|-------------|
+| Component | Type | Model | Role |
+|-----------|------|-------|------|
 | `feature-creator` | Command | (inherits) | Full pipeline: triage, plan, consolidate, review, implement, merge, clean up |
 | `feature-triager` | Agent | sonnet | Phase 0 — one shared codebase exploration pass, group issues into planning buckets by predicted file overlap |
 | `feature-planner` | Agent | sonnet | Plan every issue in a bucket together, using the triager's shared context |
@@ -53,12 +50,7 @@ Automates feature development end-to-end. Point it at a GitHub repository, label
 
 The command orchestrates the five agents. The triager runs once up front; planner agents run in parallel (one per bucket); all other agents run sequentially. Agents are not independently invocable — use the command to run the full pipeline.
 
-Key reference docs under `references/`:
-
-- `triage-guide.md` — bucketing heuristics, Jaccard overlap rule, max bucket size, singleton handling
-- `plan-template.md` — plan comment structure (includes optional Bucket-mates section)
-- `consolidated-plan-template.md` — bucket-centric consolidated plan structure
-- `risk-criteria.md`, `review-checklist.md`, `merge-checklist.md`, `pr-template.md`, `release-pr-template.md`, `repo-analysis-guide.md`
+Supporting reference docs live under `references/` — see [CLAUDE.md](../../CLAUDE.md#directory-structure) for the full list and purpose of each.
 
 ## Pipeline
 
@@ -86,7 +78,7 @@ GitHub Issues                    Pipeline                            Output
                                                                deleted
 ```
 
-The pipeline moves through six phases (Phase 0 is the new triage stage):
+The pipeline moves through six phases, 0 through 5.
 
 **Phase 0 — Triage**: The orchestrator captures a timestamp once and derives a run-scoped manifest path (`/tmp/feature-buckets-<TS>.json`). It launches the `feature-triager` agent, which fetches all trigger-labeled issues, runs **one shared codebase exploration pass**, predicts per-issue impacted globs, and groups issues into buckets by Jaccard overlap (≥ 1 shared glob). The manifest is written to the timestamped path and then validated by the orchestrator — if it is missing or malformed, the pipeline halts immediately. See `references/triage-guide.md` for the bucketing rules.
 

--- a/plugins/feature-creator/commands/feature-creator.md
+++ b/plugins/feature-creator/commands/feature-creator.md
@@ -7,7 +7,7 @@ disable-model-invocation: true
 
 # Feature Creator
 
-You are a feature pipeline orchestrator. You chain agents across five phases to
+You are a feature pipeline orchestrator. You chain agents across six phases (0–5) to
 take GitHub issues from labeled requests through to merged pull requests.
 
 **Pipeline**:

--- a/plugins/security-scanner/README.md
+++ b/plugins/security-scanner/README.md
@@ -8,27 +8,24 @@ posts expert advisory comments with root-cause analysis on each acted issue.
 
 ## Quick Start
 
-1. **Install the marketplace** (once per machine):
-   ```bash
-   /plugin marketplace add https://github.com/schmimran/claude-skills
-   ```
+1. **Install the marketplace** if you have not already: see [Installation in the root README](../../README.md#installation).
 
 2. **Create the required labels** on your target repository:
    ```bash
    gh label create "security" \
-     --color D93F0B \
+     --color d73a4a \
      --description "Security vulnerability finding"
 
    gh label create "security - suppressed" \
-     --color CCCCCC \
+     --color e4e669 \
      --description "Confirmed false positive — scanner will skip this finding"
 
    gh label create "feature - ready for claude" \
-     --color 0075ca \
+     --color 0E8A16 \
      --description "Ready for a Claude fixing agent"
 
    gh label create "feature - human review" \
-     --color 0075ca \
+     --color D93F0B \
      --description "Needs a human to review before proceeding"
    ```
 
@@ -48,7 +45,7 @@ posts expert advisory comments with root-cause analysis on each acted issue.
 
 ## Prerequisites
 
-- **Node.js** with `npm` available in the shell
+- **Node.js 18+** with `npm 7+` available in the shell (for `npm audit` and `npx`)
 - **GitHub CLI** installed and authenticated (`gh auth status`)
 - **jq** on PATH — used by the orchestrator to merge findings.  Install with
   `brew install jq` (macOS) or `apt-get install jq` / `dnf install jq` (Linux).
@@ -158,36 +155,14 @@ full fingerprint specification.
 
 ## Suppression (False Positives)
 
-To suppress a finding permanently:
-1. Open its GitHub Issue.
-2. Add the label `security - suppressed`.
-3. Add a comment explaining why it is a false positive.
-4. Leave the issue open.
-
-The scanner will skip suppressed findings on all future runs and will never
-auto-close them.  See `references/suppression-guide.md` for details.
-
-### Autonomous suppression by the advisor
-
-The `security-advisor` agent may auto-suppress a newly filed issue when ALL
-three high-confidence false-positive signals are present:
-
-1. Source is `supabase-advisor` or `supabase-schema`.
-2. Rule ID is a known FP-prone rule for that source (`rls_disabled_in_public`,
-   `rls_enabled_no_policy`, `missing_rls`, or `policy_allows_all`).
-3. The finding references a known Supabase-internal or system table
-   (`schema_migrations`, `supabase_migrations`, `supabase_functions`,
-   `_realtime`, `_analytics`, `_supabase`, `storage.buckets`,
-   `storage.objects`).
-
-When triggered, the advisor applies `security - suppressed` and
-`feature - human review` labels, removes `feature - ready for claude`, posts
-a rationale comment, and closes the issue.  Reopened issues are never
-auto-suppressed.
-
-**To reverse an auto-suppression**: remove the `security - suppressed` label.
-The next scan re-files the issue if it is still detected.  See
-`references/suppression-guide.md` for the full signal specification.
+To suppress a finding permanently, add the `security - suppressed` label to
+its GitHub Issue and leave it open; the scanner then skips it on every
+future run and never auto-closes it. The `security-advisor` agent may also
+auto-suppress a newly filed issue when it matches a known high-confidence
+false-positive pattern (Supabase-internal tables, FP-prone rule IDs); to
+reverse an auto-suppression, remove the `security - suppressed` label. See
+[`references/suppression-guide.md`](references/suppression-guide.md) for
+the full manual procedure and the auto-suppression signal specification.
 
 ## Advisory Comments
 
@@ -220,13 +195,10 @@ configuration (auth hardening, API schemas).
 
 ### Detection
 
-The Supabase auditor runs automatically if any of these signals are present
-(no flag to enable, no flag to disable):
-
-1. `supabase/config.toml` exists.
-2. `@supabase/supabase-js` is in `package.json`.
-3. `SUPABASE_URL` is set in any `.env*` file.
-4. `supabase/migrations/` has at least one `.sql` file.
+The Supabase auditor runs automatically when the repo shows any of four
+detection signals (`supabase/config.toml`, `@supabase/supabase-js`,
+`SUPABASE_URL`, `supabase/migrations/*.sql`). Full list and matcher
+rules in [`references/supabase-audit-guide.md`](references/supabase-audit-guide.md#detection).
 
 ### Two data sources
 

--- a/plugins/security-scanner/agents/security-supabase-auditor.md
+++ b/plugins/security-scanner/agents/security-supabase-auditor.md
@@ -28,13 +28,9 @@ rm -f /tmp/sec-supabase-advisors.json
 
 ## Step 2: Detect Supabase usage
 
-Check, in order — any one match is sufficient:
-
-1. `supabase/config.toml` exists.
-2. `@supabase/supabase-js` appears in `package.json` (`dependencies` or
-   `devDependencies`).
-3. `SUPABASE_URL` is set in any `.env*` file at the repo root.
-4. `supabase/migrations/` exists and has at least one `.sql` file.
+Apply the detection signals and matcher rules in
+[`../references/supabase-audit-guide.md#detection`](../references/supabase-audit-guide.md#detection).
+Any one match is sufficient.
 
 If none match, write an empty findings file and stop:
 


### PR DESCRIPTION
<!-- claude-docs-steward-v1 -->
*Generated by [docs-steward](https://github.com/schmimran/claude-skills/tree/main/plugins/docs-steward) · run `20260423T120101Z` · pipeline: Phase 0 index → Phase 1 audit → Phase 2 consolidate → Phase 3 edit → Phase 4 re-read → Phase 5 PR*

## Summary

Docs-steward reconciled documentation against the code on run `20260423T120101Z`. 11 docs were edited, 2 deprecated/orphan items were removed, and 7 restructures consolidated duplicated content across three plugins and the two root-level docs. Most drift centered on stale counts (seven-vs-eight tenets, six-vs-seven Phase 0 agents, seven-vs-six Phase 1 auditors, five-vs-six feature-creator phases), a stale docs-steward version in the root catalog (`0.3.0` → `0.5.0`), and duplicated install / Supabase-detection / suppression blocks.

## Findings applied

### Deletions (tenet 5)
- `plugins/docs-steward/agents/docs-final-reviewer.md` (Step 2 parenthetical) — drop stale link-checker reference (finding `cf-001`) — commit `2250498`
- `plugins/docs-steward/README.md` (Prerequisites) — remove stale "Internet access (the link-checker hits external URLs)" bullet (finding `cf-007`) — commit `893a047`

### Restructures (tenet 6)
- `plugins/docs-steward/README.md` Quick Start → `README.md#installation` — collapse duplicated marketplace-install block (finding `cf-009`, group `g-marketplace-install`) — commit `893a047`
- `plugins/feature-creator/README.md` Quick Start → `README.md#installation` — collapse duplicated marketplace-install block (finding `cf-014`, group `g-marketplace-install`) — commit `9fee1bf`
- `plugins/security-scanner/README.md` Quick Start → `README.md#installation` — collapse duplicated marketplace-install block (finding `cf-021`, group `g-marketplace-install`) — commit `747cb84`
- `plugins/feature-creator/README.md` references bullet-list → `CLAUDE.md#directory-structure` — remove duplicated reference-docs enumeration (finding `cf-015`) — commit `9fee1bf`
- `plugins/security-scanner/README.md` Supabase Detection block → `references/supabase-audit-guide.md#detection` — canonicalize Supabase detection signals (finding `cf-018`, group `g-supabase-detect`) — commit `747cb84`
- `plugins/security-scanner/agents/security-supabase-auditor.md` Step 2 → `../references/supabase-audit-guide.md#detection` — same canonicalization in the agent (finding `cf-019`, group `g-supabase-detect`) — commit `e6a3610`
- `plugins/security-scanner/README.md` Suppression section → `references/suppression-guide.md` — collapse 30 lines to a 3-sentence summary + link (finding `cf-020`) — commit `747cb84`

### Edits
- `plugins/docs-steward/agents/docs-consolidator.md` (Inputs) — "eight files" → "six findings files" (finding `cf-002`) — commit `8b020fd`
- `plugins/docs-steward/agents/docs-consolidator.md` (Tenet-compliance plan) — "seven tenets" → "eight tenets (0–7)" (finding `cf-003`) — commit `8b020fd`
- `plugins/docs-steward/agents/docs-editor.md` (preamble) — "seven tenets" → "eight tenets (0–7)" (finding `cf-004`) — commit `4873a3f`
- `plugins/docs-steward/commands/docs-steward.md` (Phase 0) — "six index builders" → "seven index builders" (finding `cf-005`) — commit `2f17d21`
- `plugins/feature-creator/commands/feature-creator.md` (opening) — "five phases" → "six phases (0–5)" (finding `cf-006`) — commit `b0233b8`
- `plugins/docs-steward/README.md` Architecture table — add `docs-link-checker` manual-only qualifier (finding `cf-008`) — commit `893a047`
- `plugins/docs-steward/README.md` Phase 0 — "6 parallel agents" → "7 parallel agents" and add `protected-files index` (finding `cf-010`) — commit `893a047`
- `plugins/docs-steward/README.md` Phase 1 — "7 parallel auditors" → "6 parallel auditors" with link-checker parenthetical (finding `cf-011`) — commit `893a047`
- `plugins/docs-steward/README.md` Architecture table — insert `docs-protected-extractor` row (finding `cf-012`) — commit `893a047`
- `plugins/docs-steward/README.md` References — "seven rules" → "eight core tenets (0–7)" (finding `cf-013`) — commit `893a047`
- `plugins/feature-creator/README.md` Pipeline prose — "six phases (Phase 0 is the new triage stage)" → "six phases, 0 through 5" (finding `cf-016`) — commit `9fee1bf`
- `plugins/feature-creator/README.md` Architecture table — rename column header `Description` → `Role` for peer consistency (finding `cf-017`) — commit `9fee1bf`
- `plugins/security-scanner/README.md` label creation — `feature - ready for claude` color `0075ca` → `0E8A16`, `feature - human review` color `0075ca` → `D93F0B` (finding `cf-022`) — commit `747cb84`
- `plugins/security-scanner/README.md` label creation — `security` color `D93F0B` → `d73a4a`, `security - suppressed` color `CCCCCC` → `e4e669` (finding `cf-023`) — commit `747cb84`
- `plugins/security-scanner/README.md` Prerequisites — add Node.js 18+ / npm 7+ floor (finding `cf-024`) — commit `747cb84`
- `CLAUDE.md` Directory Structure — add `release-pr-template.md` row to the feature-creator references block (finding `cf-025`) — commit `9d7b887`
- `CLAUDE.md` Prerequisites — broaden Labels bullet to cover both plugins and note canonical colors (finding `cf-026`) — commit `9d7b887`
- `README.md` plugin catalog — docs-steward version `0.3.0` → `0.5.0` (finding `cf-027`) — commit `3adc16c`
- `README.md` What Each Plugin Does — "seven critic personas" → "six critic personas" (finding `cf-028`) — commit `3adc16c`
- `README.md` Contributing — explicitly note there is no separate `CONTRIBUTING.md` (finding `cf-029`) — commit `3adc16c`

## Residual items

One nit surfaced by the Phase 4 manual-reader walk:

- **nit — `plugins/docs-steward/README.md` Architecture table ordering** (finding `manual-reader-f7a3c1`). The `docs-manual-reader` row currently sits between Phase 1 auditors and `docs-deprecation-hunter`, breaking an implicit phase-ordered reading of the table. The reordering predates this run and was not introduced by any cf-* edit. Optional pure-row-reorder fix; left for a future pass to avoid churn.

## Tenet compliance

- [x] 0. Docs untrusted until verified against source (RIGOR: `sampled` — default)
- [x] 1. READMEs are user-facing
- [x] 2. Root README is the entry point
- [x] 3. Corpus reads as a manual (verified by post-edit re-read — classification `nits_only`)
- [x] 4. Section READMEs are consistent
- [x] 5. Deprecated/orphaned content removed, not annotated
- [x] 6. No duplication
- [x] 7. Post-edit re-read performed

Summary: **8 / 8 tenets pass.** The three source-verifying auditors (intent-auditor, example-verifier, reference-validator) cited source files and lines for every count and version claim (cf-002/005/010/027 carry explicit `Verification:` citations in `consolidated-findings.md`).

## How to review

1. Start from the root `README.md` and follow links — the PR should read as a coherent manual. Notable entry points to sanity-check: the docs-steward catalog row (now `0.5.0`) and "six critic personas" line, each of which fans out into the plugin README.
2. Inspect deletions first (`git log --diff-filter=D --stat origin/main..HEAD` on the branch) — specifically the internet-access prerequisite and the Supabase detection / suppression block collapses.
3. Spot-check a few edits against the cache's indexes: `/tmp/docs-steward-cache/20260423T120101Z/indexes/`.

## Plan of action

- Human review of all sections above.
- Merge when satisfied; or push additional edits to the branch before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
