### PR TITLE
feat: add bug-sweeper plugin + extend feature-creator for bug remediation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "feature-creator",
       "source": "./plugins/feature-creator",
-      "description": "Feature development pipeline — GitHub issues to implementation plans to PRs.",
-      "version": "0.5.0",
+      "description": "Feature and bug-fix pipeline — plans, reviews, and implements GitHub issues labeled `feature - ready for claude` or `bug - ready for claude`.",
+      "version": "0.6.0",
       "author": {
         "name": "schmimran"
       }
@@ -27,6 +27,15 @@
       "source": "./plugins/docs-steward",
       "description": "Docs maintenance pipeline — builds canonical indexes of a repo, audits docs for drift, duplication, orphans, and onboarding gaps, then actively edits docs and opens a PR.",
       "version": "0.5.0",
+      "author": {
+        "name": "schmimran"
+      }
+    },
+    {
+      "name": "bug-sweeper",
+      "source": "./plugins/bug-sweeper",
+      "description": "Daily bug-discovery sweep for Node.js apps — runs build/audit + multi-agent code review, filters false positives, and files confirmed bugs as GitHub Issues for feature-creator to remediate.",
+      "version": "0.1.0",
       "author": {
         "name": "schmimran"
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,26 +12,29 @@ A Claude Code plugin **marketplace** containing reusable plugins. Install the ma
 .claude-plugin/
   marketplace.json                # Marketplace catalog — lists all plugins
 plugins/
-  feature-creator/                # Plugin: feature development pipeline
+  feature-creator/                # Plugin: feature & bug-fix development pipeline (parallel state machines)
     .claude-plugin/
       plugin.json                 # Plugin manifest
     commands/
-      feature-creator.md          # Orchestrator command — chains the agents across six phases (0-5)
+      feature-creator.md          # Orchestrator command — chains the agents across six phases (0-5); processes both feature and bug labels
     agents/
-      feature-triager.md          # Agent (Phase 0): shared codebase exploration, bucket issues by predicted file overlap
-      feature-planner.md          # Agent: plan every issue in a bucket together, posts per-issue plan comments
-      feature-consolidator.md     # Agent: collect plans, cross-bucket conflict analysis
-      feature-reviewer.md         # Agent: risk assessment, combined plan, review
-      feature-implementer.md      # Agent: branch, code, test, PR
+      feature-triager.md          # Agent (Phase 0): shared codebase exploration; buckets features and bugs separately by predicted file overlap
+      feature-planner.md          # Agent: plan every issue in a bucket together using type-appropriate template
+      feature-consolidator.md     # Agent: collect plans, cross-bucket conflict analysis (per type)
+      feature-reviewer.md         # Agent: type-tuned risk assessment, combined plan, review
+      feature-implementer.md      # Agent: type-aware branch (feature/<N>- or fix/<N>-), code, test, PR (feat: or fix:)
     references/
-      triage-guide.md             # Bucketing heuristics, Jaccard overlap rule, max bucket size, singleton handling
-      plan-template.md            # Template for plan comments (includes optional Bucket-mates section)
+      triage-guide.md             # Bucketing heuristics + type-separation rule (features and bugs never share a bucket)
+      plan-template.md            # Feature plan template (Bucket-mates optional)
+      bug-plan-template.md        # Bug-fix plan template (requires Reproduction Steps, Root Cause, regression test)
       consolidated-plan-template.md # Bucket-centric template for consolidated plan comments
       repo-analysis-guide.md      # What to look for in the target repo
-      risk-criteria.md            # Risk rubric (HIGH/MEDIUM/LOW)
-      review-checklist.md         # Instructions for the review subagent
-      merge-checklist.md          # Pre-merge steps
-      pr-template.md              # PR body template
+      risk-criteria.md            # Feature risk rubric (HIGH/MEDIUM/LOW)
+      bug-risk-criteria.md        # Bug-tuned risk rubric — different factors than features (some flip)
+      review-checklist.md         # Review subagent checklist for feature plans
+      bug-review-checklist.md     # Review subagent checklist for bug-fix plans (regression test required)
+      merge-checklist.md          # Pre-merge steps with type-aware commit type (feat: vs fix:)
+      pr-template.md              # PR body template (Root Cause section for bug fixes)
       release-pr-template.md      # Release PR body template for the release branch PR assembled in Phase 5c
     README.md                     # Plugin-specific documentation
   security-scanner/               # Plugin: multi-tool security audit for Node.js + Supabase
@@ -89,6 +92,26 @@ plugins/
       manual-reader-protocol.md   # How the manual-reader walks the edited corpus (Phase 4)
       cache-layout.md             # /tmp/docs-steward-cache/ layout and lifecycle
       pr-template.md              # PR body template (sections: findings, deletions, requires-approval, residuals, tenets)
+    README.md                     # Plugin-specific documentation
+  bug-sweeper/                    # Plugin: daily bug-discovery sweep, files issues for feature-creator to remediate
+    .claude-plugin/
+      plugin.json                 # Plugin manifest
+    commands/
+      bug-sweeper.md              # Orchestrator command — chains the six phases (0-6); supports --headless mode for routines
+    agents/
+      bug-sweeper-runner.md       # Phase 1: gh issue list + npm build + npm audit (parallel Bash)
+      bug-sweeper-reviewer.md     # Phase 2: targeted code review of one directory (read-only — no Write/Edit)
+      bug-sweeper-tracer.md       # Phase 2: end-to-end trace of one high-risk flow (read-only)
+      bug-sweeper-reconciler.md   # Phase 3: classify open `bug` issues vs current code (still-open / fixed / docs-only)
+      bug-sweeper-analyst.md      # Phase 4 + 5: false-positive filter, severity assignment, plan + self-review
+      bug-sweeper-filer.md        # Phase 6: file each confirmed bug as a GitHub Issue with severity label
+    references/
+      bug-sweep-protocol.md       # End-to-end pipeline contract + global CLAUDE.md overrides for sweeps
+      discovery-surface-guide.md  # How to locate API dir, web dir, hot-path entry on arbitrary Node.js repos
+      false-positive-rubric.md    # Discard rules (D1–D9) the analyst applies to candidate findings
+      severity-rubric.md          # HIGH/MEDIUM/LOW criteria for confirmed bugs
+      bug-issue-template.md       # GitHub Issue body format with `<!-- claude-bug-sweeper-v1 -->` marker
+      headless-mode.md            # What changes when `--headless` is passed (no plan mode, no AskUserQuestion)
     README.md                     # Plugin-specific documentation
 ```
 
@@ -173,9 +196,17 @@ Agents declare tool access with the `tools:` field. Common tool sets:
 
 - **Naming**: Directory names are lowercase with hyphens (e.g., `feature-creator`)
 - **Issue interaction**: Plans are posted as comments, never by modifying the issue body
-- **Branching**: One branch per feature (`feature/<number>-<slug>`), plus a release branch (`release/<YYYY-MM-DD>`) after all features
-- **Commits**: Conventional commit format, referencing the issue number (e.g., `feat: add widget (#42)`)
-- **Comment markers**: Plan comments are prefixed with `<!-- claude-feature-planner-v1 -->`, consolidated plans with `<!-- claude-feature-consolidator-v1 -->`, and combined reviewer plans with `<!-- claude-feature-reviewer-v1 -->`. Downstream agents use these markers to locate content programmatically. Always include the correct marker or extraction will fail.
+- **Branching**: One branch per change rooted at `stage` — `feature/<number>-<slug>` for features, `fix/<number>-<slug>` for bug fixes — plus a single release branch (`release/<YYYY-MM-DD>`) after all branches are implemented
+- **Commits**: Conventional commit format, referencing the issue number. `feat: add widget (#42)` for features, `fix: prevent crash on logout (#21)` for bugs.
+- **Comment markers**: Used by downstream agents to locate content. Always include the correct marker — extraction will fail otherwise.
+
+| Stage | Feature marker | Bug marker |
+|-------|----------------|------------|
+| Triager | `<!-- claude-feature-triager-v1 -->` | (shared — same triager handles both) |
+| Planner | `<!-- claude-feature-planner-v1 -->` | `<!-- claude-bug-planner-v1 -->` |
+| Consolidator | `<!-- claude-feature-consolidator-v1 -->` | `<!-- claude-bug-consolidator-v1 -->` |
+| Reviewer | `<!-- claude-feature-reviewer-v1 -->` | `<!-- claude-bug-reviewer-v1 -->` |
+| Bug-sweeper issue body | n/a | `<!-- claude-bug-sweeper-v1 -->` |
 
 ## Local Development
 
@@ -194,8 +225,16 @@ claude --plugin-dir /path/to/claude-skills/plugins/feature-creator
 
 ## Prerequisites
 
-- **`gh` CLI**: Must be installed and authenticated (`gh auth status`)
-- **Labels**: Each plugin that files or reads GitHub Issues requires its own label set on the target repository. See the Quick Start section of each plugin's README for the `gh label create` commands: feature-creator defines five `feature - *` pipeline labels, and security-scanner defines two `security` labels plus two shared `feature -` labels. Where label names are shared across plugins (notably `feature - ready for claude` and `feature - human review`), the colors and descriptions in feature-creator's README are canonical — use those when creating labels.
+- **`gh` CLI**: Must be installed and authenticated (`gh auth status`).
+- **Labels**: Each plugin that files or reads GitHub Issues requires its own label set on the target repository. See the Quick Start section of each plugin's README for the `gh label create` commands.
+
+| Plugin | Labels it defines |
+|--------|-------------------|
+| feature-creator | Feature state machine: `feature - ready for claude`, `feature - planned`, `feature - human review`, `feature - in progress`, `feature - complete`. Bug state machine (shared with bug-sweeper): `bug`, `bug - ready for claude`, `bug - triaged`, `bug - planned`, `bug - human review`, `bug - in progress`, `bug - complete`, `bug - high`, `bug - medium`, `bug - low`. |
+| bug-sweeper | Files issues with `bug`, `bug - ready for claude`, and one of the severity labels (`bug - high|medium|low`) — all defined in feature-creator's set; bug-sweeper does not introduce its own labels |
+| security-scanner | `security`, `security - suppressed`, plus shared `feature - ready for claude` and `feature - human review` |
+
+Where label names are shared across plugins (notably `feature - ready for claude`, `feature - human review`, and the entire `bug - *` set), the colors and descriptions in feature-creator's README are canonical — use those when creating labels.
 
 ## Build & Test Commands
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,20 @@ Plugins are self-contained: each lives in its own directory with its own agents,
 
 | Plugin | Version | Description | Docs |
 |--------|---------|-------------|------|
-| [feature-creator](plugins/feature-creator/) | 0.5.0 | Feature development pipeline — GitHub issues to implementation plans to PRs | [README](plugins/feature-creator/README.md) |
+| [feature-creator](plugins/feature-creator/) | 0.6.0 | Feature and bug-fix pipeline — GitHub issues to implementation plans to PRs (handles `feature - ready for claude` and `bug - ready for claude`) | [README](plugins/feature-creator/README.md) |
 | [security-scanner](plugins/security-scanner/) | 0.4.0 | Multi-tool security audit for Node.js web apps and Supabase projects — files findings as GitHub Issues with deduplication, reopen on re-detection, and expert advisory comments | [README](plugins/security-scanner/README.md) |
 | [docs-steward](plugins/docs-steward/) | 0.5.0 | Docs maintenance pipeline — builds canonical indexes of a repo, audits docs for drift, duplication, orphans, and onboarding gaps, then actively edits docs and opens a PR | [README](plugins/docs-steward/README.md) |
+| [bug-sweeper](plugins/bug-sweeper/) | 0.1.0 | Daily bug-discovery sweep for Node.js apps — runs build/audit + multi-agent code review, filters false positives, and files confirmed bugs as GitHub Issues for feature-creator to remediate | [README](plugins/bug-sweeper/README.md) |
 
 ## What Each Plugin Does
 
-**feature-creator** — Give it a GitHub repository and some labeled issues, and it handles the full development cycle automatically. It reads your codebase, writes a detailed implementation plan for each issue, checks whether each change is risky (and flags anything dangerous for human review), writes the code, runs your tests, opens pull requests, and — if you want — merges and cleans up. The only time it stops to ask is when it flags something as high-risk, or when you've asked it to pause before the final merge.
+**feature-creator** — Give it a GitHub repository and some labeled issues (features or bugs), and it handles the full development cycle automatically. It reads your codebase, writes a detailed implementation plan for each issue (using a feature template or a bug-fix template depending on the label), checks whether each change is risky (with type-tuned rubrics — bug fixes have a different risk profile than new features), writes the code, runs your tests, opens pull requests with the right conventional-commit type (`feat:` or `fix:`), and — if you want — merges and cleans up. The only time it stops to ask is when it flags something as high-risk, or when you've asked it to pause before the final merge.
 
 **security-scanner** — Runs a multi-tool security audit against a Node.js web app and, when present, its Supabase project. Files findings as labeled GitHub Issues, deduplicates by fingerprint so you don't get the same issue twice, reopens previously closed issues when a scan re-detects them, auto-closes resolved ones, and adds expert advisory comments with root-cause analysis on every new or reopened issue.
 
 **docs-steward** — Brings documentation in line with what the code actually does. Builds canonical indexes of the repo (files, symbols, routes, config, doc inventory, recent history), runs six critic personas in parallel to find drift, duplication, stale references, orphan config keys, and onboarding gaps, then actively edits the docs on a feature branch — deleting deprecated content, moving duplicated content to a single canonical home, and fixing stale claims. A manual-reader persona reads the edited corpus before opening a single PR. The PR is never auto-merged.
+
+**bug-sweeper** — Daily bug-discovery sweep designed to run unattended (typically from a `/schedule` routine in permissions-bypass mode). Runs `npm run build` and `npm audit`, launches parallel code-review agents on the API and web surfaces, traces a high-risk flow end-to-end, reconciles findings against open `bug` issues, applies a false-positive rubric, and files each confirmed bug as a GitHub Issue labeled `bug - ready for claude` with a severity label. It does **not** propose fixes or modify code — remediation is handled by feature-creator, which picks up the filed issues automatically.
 
 ## Contributing a Plugin
 

--- a/plugins/bug-sweeper/.claude-plugin/plugin.json
+++ b/plugins/bug-sweeper/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "bug-sweeper",
+  "description": "Daily bug-discovery sweep — runs build/audit + multi-agent code review, filters false positives, files confirmed bugs as GitHub Issues for feature-creator to remediate.",
+  "version": "0.1.0",
+  "author": {
+    "name": "schmimran"
+  }
+}

--- a/plugins/bug-sweeper/README.md
+++ b/plugins/bug-sweeper/README.md
@@ -1,0 +1,225 @@
+# bug-sweeper
+
+Daily bug-discovery sweep for Node.js / TypeScript repositories. Runs build
+and audit checks, launches multi-agent code review, filters false positives,
+and files each confirmed bug as a labeled GitHub Issue. The downstream
+[feature-creator](../feature-creator/) plugin remediates the filed issues.
+
+This plugin is **find-only**. It does not propose fixes, plan code changes,
+or modify the repo.
+
+## Quick Start
+
+1. **Install the marketplace** if you have not already: see [Installation in the root README](../../README.md#installation).
+
+2. **Create the required labels** on your target repository (once per repo):
+   ```bash
+   gh label create "bug" \
+     --color d73a4a \
+     --description "Defect in the codebase"
+
+   gh label create "bug - ready for claude" \
+     --color 0E8A16 \
+     --description "Bug filed by bug-sweeper, ready for feature-creator to remediate"
+
+   gh label create "bug - high" \
+     --color B60205 \
+     --description "High-severity bug — data loss, security, hot-path crash, partial commit"
+
+   gh label create "bug - medium" \
+     --color D93F0B \
+     --description "Medium-severity bug — non-critical regression, leak, UI consistency"
+
+   gh label create "bug - low" \
+     --color FBCA04 \
+     --description "Low-severity bug — cosmetic, doc drift, defensive-coding gap"
+   ```
+
+   You also need feature-creator's bug state-machine labels — see the
+   [feature-creator README](../feature-creator/README.md#quick-start) for
+   the full list including `bug - triaged`, `bug - planned`,
+   `bug - in progress`, `bug - complete`, and `bug - human review`.
+
+3. **Run an interactive sweep** to inspect findings before any issues are
+   filed:
+   ```
+   /bug-sweeper owner/repo
+   ```
+   The pipeline enters plan mode at Phase 5 and waits for your approval
+   before filing any GitHub issue.
+
+4. **Run a headless sweep** (typically from a `/schedule` routine in
+   permissions-bypass mode):
+   ```
+   /bug-sweeper owner/repo --headless
+   ```
+   The analyst's Phase 5 self-review replaces human approval. Issues are
+   filed automatically.
+
+## Prerequisites
+
+- **Node.js 18+** with `npm 7+` available in the shell (for `npm run build`
+  and `npm audit`)
+- **GitHub CLI** (`gh`) installed, on `PATH`, and authenticated
+  (`gh auth status`)
+- The target repository must be a Node.js / TypeScript project with a
+  recognizable server entry point. See
+  [`references/discovery-surface-guide.md`](references/discovery-surface-guide.md)
+  for which directory layouts are recognized.
+- Required labels created on the target repository (see Quick Start above)
+
+## Architecture
+
+| Component | Type | Model | Role |
+|-----------|------|-------|------|
+| `bug-sweeper` | Command | (inherits) | Orchestrates Phases 0–6 |
+| `bug-sweeper-runner` | Agent | sonnet | Phase 1 — gh issue list, npm build, npm audit (parallel Bash) |
+| `bug-sweeper-reviewer` | Agent | sonnet | Phase 2 — targeted code review of one directory |
+| `bug-sweeper-tracer` | Agent | sonnet | Phase 2 — end-to-end trace of one high-risk flow |
+| `bug-sweeper-reconciler` | Agent | sonnet | Phase 3 — classify open `bug` issues against current code |
+| `bug-sweeper-analyst` | Agent | sonnet | Phase 4 + 5 — false-positive filter, severity, plan, self-review |
+| `bug-sweeper-filer` | Agent | sonnet | Phase 6 — file confirmed bugs as GitHub Issues |
+
+None of the discovery / review agents have `Write` or `Edit` access. Only
+the filer touches GitHub. This enforces the "find only, never fix" boundary
+at the tool layer.
+
+## Pipeline
+
+```
+Target Repo
+    |
+    v
+bug-sweeper-runner   (gh, npm build, npm audit — parallel Bash)
+    |
+    v
+/tmp/bug-sweeper-signals.json
+    |
+    +------- bug-sweeper-reviewer (API surface) ------+
+    +------- bug-sweeper-reviewer (web surface) ------+   (parallel)
+    +------- bug-sweeper-tracer   (hot path)     -----+
+    |
+    v
+bug-sweeper-reconciler   (classify open `bug` issues)
+    |
+    v
+bug-sweeper-analyst   (false-positive filter, severity, self-review)
+    |
+    v
+/tmp/bug-sweeper-plan.json
+    |
+    [Phase 5 approval gate — interactive only]
+    |
+    v
+bug-sweeper-filer   (gh issue create with --body-file per bug)
+    |
+    v
+GitHub Issues filed with `bug`, `bug - ready for claude`, severity label
+```
+
+## Modes
+
+| Mode | Plan mode | Approval gate | Use case |
+|------|-----------|---------------|----------|
+| **Interactive** (default) | Enters plan mode at Phase 5 | User approves before filing | Manual run; human reviewing the bug list |
+| **Headless** (`--headless`) | Skips plan mode | Self-review replaces approval | Scheduled routine in permissions-bypass mode |
+
+## Coverage
+
+| Bug class | Detected by |
+|---|---|
+| TypeScript build errors | runner (`npm run build`) |
+| Dependency CVEs | runner (`npm audit`) |
+| Missing awaits, silent error swallowing, async ordering | reviewer (API surface) |
+| State consistency, DOM cleanup, XSS, SSE/streaming error recovery | reviewer (web surface) |
+| End-to-end ordering / partial-commit / concurrency in a hot flow | tracer |
+| Already-known bugs | reconciler (cross-checks open `bug` issues) |
+
+## Severity → label
+
+| Analyst severity | Label applied |
+|---|---|
+| HIGH | `bug - high` |
+| MEDIUM | `bug - medium` |
+| LOW | `bug - low` |
+
+LOW-severity bugs are filed but feature-creator deprioritizes them — LOW
+is a queue, not a discard.
+
+## Issue body format
+
+Every issue filed by bug-sweeper begins with the marker
+`<!-- claude-bug-sweeper-v1 -->`. The body includes the file:line, severity,
+root cause (one sentence), reproduction steps, and a "Suggested area to
+investigate" pointer for the human reader. There is no "proposed fix"
+section — that is feature-creator's responsibility.
+
+See [`references/bug-issue-template.md`](references/bug-issue-template.md)
+for the exact format.
+
+## Handoff to feature-creator
+
+Once an issue is filed with `bug - ready for claude`, feature-creator
+processes it through a parallel state machine:
+
+```
+bug - ready for claude → bug - triaged → bug - planned → bug - in progress → bug - complete
+                                              ↓ (high risk)
+                                         bug - human review
+```
+
+Branch name: `fix/<N>-<slug>`. Commit type: `fix:`. Plan template:
+[`bug-plan-template.md`](../feature-creator/references/bug-plan-template.md).
+Risk rubric:
+[`bug-risk-criteria.md`](../feature-creator/references/bug-risk-criteria.md).
+
+## Deduplication (current state)
+
+v0.1.0 does **not** fingerprint findings. Each daily run files fresh
+issues. The reconciler does cross-check against currently-open `bug`
+issues to avoid filing literal duplicates within a single run, but bugs
+filed on consecutive days that re-detect the same defect will produce
+new issues.
+
+The `<!-- claude-bug-sweeper-v1 -->` marker is reserved on every issue body
+so a future closer/triager agent can be added (mirroring security-scanner's
+pattern) without breaking historical issues.
+
+## Scheduling
+
+Wrap in a scheduled task for daily runs:
+
+```
+Task: bug-sweeper-daily
+Cron: 0 7 * * *
+Prompt: Run "/bug-sweeper owner/repo --headless"
+Mode: permissions-bypass
+```
+
+The task must run in a worktree of the target repo so `npm run build` and
+`npm audit` operate on a clean checkout. The scheduler is responsible for
+worktree creation and cleanup.
+
+## Known Limitations
+
+- Node.js / TypeScript only. Repos using other stacks fall through repo-shape
+  discovery and the pipeline halts.
+- Test failures (`npm test`) are not collected as a bug signal in v0.1.0.
+  Possible future signal — track via README issues.
+- No fingerprint-based dedup. Re-detection across runs produces duplicate
+  issues. Track via README issues if this becomes a problem.
+- Slack/email notifications on HIGH-severity findings are out of scope.
+
+## Possible future signals
+
+- `npm test` results (currently excluded; tests are noisy and often need
+  human triage to distinguish flakes from regressions)
+- ESLint errors filtered to specific rule sets
+- Type-coverage regressions (e.g., new `any` introductions)
+
+If you find yourself wishing the sweep caught a bug class it doesn't, file
+an issue against this plugin's directory.
+
+## License
+
+[MIT](../../LICENSE)

--- a/plugins/bug-sweeper/README.md
+++ b/plugins/bug-sweeper/README.md
@@ -20,7 +20,7 @@ or modify the repo.
 
    gh label create "bug - ready for claude" \
      --color 0E8A16 \
-     --description "Bug filed by bug-sweeper, ready for feature-creator to remediate"
+     --description "Bug ready for automated planning (typically filed by bug-sweeper)"
 
    gh label create "bug - high" \
      --color B60205 \

--- a/plugins/bug-sweeper/agents/bug-sweeper-analyst.md
+++ b/plugins/bug-sweeper/agents/bug-sweeper-analyst.md
@@ -1,0 +1,189 @@
+---
+name: bug-sweeper-analyst
+description: Phase 4 — applies the false-positive rubric, assigns severity, and produces the structured plan of confirmed bugs
+tools: Read, Grep, TodoWrite
+model: sonnet
+color: green
+disable-model-invocation: true
+---
+
+# Bug Sweeper Analyst
+
+You take the raw signals (Phase 1) and candidate findings (Phase 2) and the
+reconciliation report (Phase 3), and you produce **the** plan: a structured
+list of confirmed bugs with severity and a list of false positives discarded
+with reasons.
+
+You are the rigor checkpoint for the pipeline. Your job is to be skeptical:
+when a finding can plausibly be ruled out, rule it out.
+
+## Prompt Protocol
+
+Your prompt contains:
+
+- `OWNER/REPO` — target repository
+- `Signals path` — `/tmp/bug-sweeper-signals.json` (from runner)
+- `Review paths` — comma-separated list of reviewer/tracer outputs
+  (e.g. `/tmp/bug-sweeper-review-api.json,/tmp/bug-sweeper-review-web.json,/tmp/bug-sweeper-trace.json`)
+- `Reconciliation path` — `/tmp/bug-sweeper-reconciliation.json`
+- `Output path` — where to write the analyst plan
+  (e.g. `/tmp/bug-sweeper-plan.json`)
+
+## Step 1: Load All Inputs
+
+Read every input file with these contracts:
+
+- **Signals** (`/tmp/bug-sweeper-signals.json`): the orchestrator gates on
+  this file's existence before launching you, so it must be present. If it
+  is missing or malformed when you read it, exit with an explicit error —
+  this is a fatal pipeline state, not partial input.
+- **Reviewer / tracer outputs**: any of these may be absent if the
+  corresponding agent failed or was skipped (e.g. `WEB_DIR` was not
+  discovered). Continue with the inputs that are present, but record in
+  the plan an explicit `unavailable_inputs` list naming each missing
+  path so the human reader sees the gap rather than assuming the surface
+  was clean.
+- **Reconciliation** (`/tmp/bug-sweeper-reconciliation.json`): if missing,
+  proceed without cross-checking against open issues but record the
+  gap — every confirmed bug will then be filed without `existing_issue`
+  matching.
+
+## Step 2: Apply the False-Positive Rubric
+
+Read `references/false-positive-rubric.md` (sibling of this file). For each
+candidate finding from the reviewer/tracer outputs, decide:
+
+- **CONFIRMED** — passes the rubric, gets filed
+- **DISCARDED** — matches one of the false-positive patterns, recorded with
+  the reason
+
+For every CONFIRMED finding, you must have **read the cited file and line
+range yourself**. Do not trust the reviewer's snippet alone — re-read the
+file before promoting a candidate to confirmed. Drop any candidate whose
+file:line you cannot verify.
+
+For every DISCARDED finding, record the specific reason from the rubric.
+Generic dismissals ("seems fine") are not acceptable.
+
+## Step 3: Promote Build and Audit Failures
+
+If the runner's `build.exit_code != 0`, treat the build failure as a single
+finding. Severity:
+
+- TypeScript errors that imply a type contract is wrong → HIGH
+- Stale generated files → MEDIUM
+- Transient network/env issues → DISCARDED with reason "transient-build-failure"
+
+If the runner's `audit.severity_counts.critical > 0` or `high > 0`, each
+critical/high vulnerability becomes a finding. Severity maps directly:
+audit critical → HIGH, audit high → HIGH, audit moderate → MEDIUM, audit low
+→ LOW (and LOW findings are typically not filed; see severity rubric).
+
+## Step 4: Assign Severity
+
+Read `references/severity-rubric.md`. For each CONFIRMED finding, assign
+exactly one of HIGH, MEDIUM, LOW.
+
+Cross-check: severities for related findings should be internally
+consistent. If two findings describe similar failure modes in similar
+contexts, their severities should match unless you can articulate why.
+
+## Step 5: Cross-Reference the Reconciliation
+
+For each confirmed finding, check whether it overlaps with an issue already
+classified as `still-open` in the reconciliation report. If it does, mark
+the finding with `existing_issue: <number>` so the filer can skip filing a
+duplicate this run.
+
+The user opted out of fingerprint-based dedup for v0.1.0, but a literal
+match against an already-open issue is cheap and worth catching.
+
+## Step 6: Self-Review (Phase 5 of the prompt — collapsed into this agent)
+
+Before writing the output, re-read your confirmed-bugs list and check:
+
+- Two confirmed bugs that touch the same lines (only one should be filed)
+- Severities that contradict each other given the same risk pattern
+- Confirmed bugs whose file:line you didn't actually re-read
+- Implementation order assumptions baked into the plan that aren't
+  necessary (this plan is for filing, not implementing — keep it independent)
+
+Drop or correct findings that fail self-review. Do not include speculative
+findings.
+
+## Step 7: Emit the Plan
+
+Write JSON to your output path:
+
+```json
+{
+  "scan_timestamp": "<ISO 8601 UTC from signals>",
+  "repo": "<OWNER/REPO>",
+  "confirmed_bugs": [
+    {
+      "id": "bug-1",
+      "category": "missing-await|silent-failure|...|build-error|cve",
+      "file": "apps/api/src/sweep.ts",
+      "line_start": 142,
+      "line_end": 148,
+      "severity": "HIGH|MEDIUM|LOW",
+      "title": "<one-line title for the issue>",
+      "root_cause": "<one sentence>",
+      "snippet": "<exact code, max 8 lines>",
+      "reproduction": "<concrete repro steps if knowable, else 'see code path'>",
+      "investigate": "<area to investigate — NOT a fix>",
+      "references": {
+        "related_commits": ["<hash>"],
+        "related_issues": [<N>],
+        "existing_issue": <N or null>
+      }
+    }
+  ],
+  "false_positives": [
+    {
+      "source_file": "apps/web/public/app.js",
+      "source_line_start": 88,
+      "category": "...",
+      "claim": "<original reviewer claim>",
+      "discard_reason": "<specific reason from the rubric>"
+    }
+  ],
+  "open_issues_status": [
+    { "number": 42, "classification": "still-open", "evidence": "..." }
+  ]
+}
+```
+
+## Step 8: Output Summary
+
+Print:
+
+```
+## Bug Sweep Plan
+
+### Confirmed bugs
+| ID | File:Lines | Severity | Title |
+|----|------------|----------|-------|
+| bug-1 | apps/api/src/sweep.ts:142-148 | HIGH | <title> |
+
+### False positives discarded
+| Source | Reason |
+|--------|--------|
+| ... | ... |
+
+### Open issues reconciled
+<table from the reconciliation report>
+```
+
+State the output path.
+
+## Boundaries
+
+- You do not propose fixes. The issue body's "Suggested area to investigate"
+  describes what to look at, not what to change. feature-creator owns
+  remediation planning.
+- You do not assess implementation risk. The risk rubric in feature-creator
+  is for that.
+- You do not file issues. The filer does that after this plan is approved.
+- Every confirmed bug must cite a file and line range you re-read in this
+  agent (not just inherited from a reviewer claim).

--- a/plugins/bug-sweeper/agents/bug-sweeper-filer.md
+++ b/plugins/bug-sweeper/agents/bug-sweeper-filer.md
@@ -70,23 +70,54 @@ Map the analyst's severity to a label:
 LOW-severity findings are filed but feature-creator may deprioritize them.
 This is intentional: LOW is a queue, not a discard.
 
-### 2d. Compose the title
+### 2d. Compose the title — never interpolate untrusted text into the shell
 
-Use the analyst's `title` field. Prefix with `[bug]` if the title does not
-already begin with that prefix. Maximum 100 characters; truncate at a word
-boundary if longer.
+The analyst's `title` field is derived from grep/read of arbitrary
+target-repo strings (identifiers, error messages, code comments). Treat it
+as untrusted. Per CLAUDE.md's shell-safety rule, **never** substitute the
+title text into a `--title "..."` argument by string-formatting the bash
+command. Instead, extract it into a shell variable using `jq` (which does
+not re-interpret content), then pass that variable through `gh` quoted —
+bash does not re-expand metacharacters inside a quoted variable.
+
+Apply these transforms before filing:
+
+1. Extract the raw title from the plan JSON for the current bug `<ID>`:
+   ```
+   RAW_TITLE=$(jq -r ".confirmed_bugs[] | select(.id==\"<ID>\") | .title" /tmp/bug-sweeper-plan.json)
+   ```
+2. Prefix with `[bug] ` if the raw title does not already begin with that
+   prefix:
+   ```
+   case "$RAW_TITLE" in
+     "[bug] "*) TITLE="$RAW_TITLE" ;;
+     *)         TITLE="[bug] $RAW_TITLE" ;;
+   esac
+   ```
+3. Truncate to 100 characters at a word boundary:
+   ```
+   TITLE=$(printf '%s' "$TITLE" | cut -c1-100 | sed 's/[[:space:]][^[:space:]]*$//')
+   ```
+
+Do **not** echo `$TITLE` into a here-doc, format string, or command
+substitution that re-interprets it. Pass it as an argument only.
 
 ### 2e. Create the issue
 
 ```
 ISSUE_URL=$(gh issue create \
-  --repo <OWNER/REPO> \
-  --title "<TITLE>" \
+  --repo "<OWNER/REPO>" \
+  --title "$TITLE" \
   --body-file /tmp/bug-issue-<ID>.md \
   --label bug \
   --label "bug - ready for claude" \
   --label "<severity-label>")
 ```
+
+`"$TITLE"` is a bash quoted variable expansion — bash substitutes the
+literal contents of `TITLE` and does not re-evaluate `$`, backticks, or
+other metacharacters inside it. This satisfies the shell-safety rule even
+when the analyst's title contains code-derived content.
 
 Capture the issue URL from stdout. Parse the issue number from the URL.
 

--- a/plugins/bug-sweeper/agents/bug-sweeper-filer.md
+++ b/plugins/bug-sweeper/agents/bug-sweeper-filer.md
@@ -1,0 +1,155 @@
+---
+name: bug-sweeper-filer
+description: Phase 6 — files each confirmed bug as a GitHub Issue with `bug - ready for claude` and a severity label
+tools: Bash, Read, TodoWrite
+model: sonnet
+color: green
+disable-model-invocation: true
+---
+
+# Bug Sweeper Filer
+
+You read the analyst's plan and create one GitHub Issue per confirmed bug.
+Every issue gets the `bug - ready for claude` trigger label and one severity
+label so feature-creator can pick it up and prioritize it.
+
+You do not modify code or post other comments. You write issues, that is all.
+
+## Prompt Protocol
+
+Your prompt contains:
+
+- `OWNER/REPO` — target repository
+- `Plan path` — `/tmp/bug-sweeper-plan.json` (from analyst)
+- `Output path` — where to write the filing summary
+  (e.g. `/tmp/bug-sweeper-filed.json`)
+
+## Step 1: Load the Plan
+
+Read the JSON. If `confirmed_bugs` is empty, write an empty filing summary
+to your output path and exit with the message "No confirmed bugs — no
+issues filed." This is a normal outcome; do not error.
+
+## Step 2: For Each Confirmed Bug
+
+For every entry in `confirmed_bugs`:
+
+### 2a. Skip if already covered
+
+If `references.existing_issue` is non-null, skip filing — the analyst found
+the bug already has an open issue. Record it in the filing summary as
+`status: "skipped-existing"` with the existing issue number.
+
+### 2b. Compose the issue body
+
+Read `references/bug-issue-template.md` (sibling of this file). Render the
+template by substituting fields from the confirmed bug. Write the rendered
+body to a per-bug temp file:
+
+```
+cat > /tmp/bug-issue-<ID>.md << 'BUG_EOF'
+<!-- claude-bug-sweeper-v1 -->
+<RENDERED_TEMPLATE>
+BUG_EOF
+```
+
+The body **must** begin with `<!-- claude-bug-sweeper-v1 -->` on the first
+line. Future closer/triager agents (when added) will use this marker to
+locate sweeper-filed issues.
+
+Always use `--body-file` — never interpolate the body into the shell.
+
+### 2c. Determine the severity label
+
+Map the analyst's severity to a label:
+
+- `HIGH` → `bug - high`
+- `MEDIUM` → `bug - medium`
+- `LOW` → `bug - low`
+
+LOW-severity findings are filed but feature-creator may deprioritize them.
+This is intentional: LOW is a queue, not a discard.
+
+### 2d. Compose the title
+
+Use the analyst's `title` field. Prefix with `[bug]` if the title does not
+already begin with that prefix. Maximum 100 characters; truncate at a word
+boundary if longer.
+
+### 2e. Create the issue
+
+```
+ISSUE_URL=$(gh issue create \
+  --repo <OWNER/REPO> \
+  --title "<TITLE>" \
+  --body-file /tmp/bug-issue-<ID>.md \
+  --label bug \
+  --label "bug - ready for claude" \
+  --label "<severity-label>")
+```
+
+Capture the issue URL from stdout. Parse the issue number from the URL.
+
+### 2f. Record the result
+
+Append to the filing summary:
+
+```json
+{
+  "id": "bug-1",
+  "status": "filed|skipped-existing|error",
+  "issue_number": 142,
+  "issue_url": "https://github.com/...",
+  "severity": "HIGH"
+}
+```
+
+## Step 3: Emit the Filing Summary
+
+Write JSON to your output path:
+
+```json
+{
+  "filed_at": "<ISO 8601 UTC>",
+  "repo": "<OWNER/REPO>",
+  "filed": [ { ... } ],
+  "skipped_existing": [ { ... } ],
+  "errors": [ { "id": "bug-3", "error": "..." } ]
+}
+```
+
+## Step 4: Output Summary
+
+Print:
+
+```
+## Filing Summary
+- Filed: X
+- Skipped (existing issue): X
+- Errors: X
+
+| ID | Severity | Status | Issue |
+|----|----------|--------|-------|
+| bug-1 | HIGH | filed | #142 |
+| bug-2 | MEDIUM | skipped-existing | #98 |
+```
+
+## Error Handling
+
+If `gh issue create` fails for one bug, log the error in the summary and
+continue with the next bug. Partial filing is preferable to halting on the
+first failure.
+
+If the required labels (`bug`, `bug - ready for claude`, `bug - high`,
+`bug - medium`, `bug - low`) are missing on the repo, the orchestrator was
+supposed to verify them before launching you. If you encounter a label
+error, exit non-zero so the orchestrator surfaces the missing-label state
+clearly.
+
+## Boundaries
+
+- You only file issues. You do not edit existing issues, comment on them,
+  or change their labels.
+- You do not assign issues to users. feature-creator's downstream agents
+  pick them up automatically via labels.
+- Every issue body begins with `<!-- claude-bug-sweeper-v1 -->`.

--- a/plugins/bug-sweeper/agents/bug-sweeper-reconciler.md
+++ b/plugins/bug-sweeper/agents/bug-sweeper-reconciler.md
@@ -1,0 +1,105 @@
+---
+name: bug-sweeper-reconciler
+description: Phase 3 — classifies open `bug` issues against current code and recent commits (still-open / fixed / docs-only)
+tools: Bash, Read, Grep, TodoWrite
+model: sonnet
+color: blue
+disable-model-invocation: true
+---
+
+# Bug Sweeper Reconciler
+
+You read the list of currently-open issues labeled `bug` and classify each
+one against the current state of the repository. The analyst uses your
+classifications to decide whether to re-file, leave alone, or note the
+issue as already addressed.
+
+## Prompt Protocol
+
+Your prompt contains:
+
+- `OWNER/REPO` — target repository
+- `Open bugs path` — JSON file written by the runner
+  (`/tmp/bug-sweeper-open-bugs.json`)
+- `Output path` — where to write your reconciliation report
+  (e.g. `/tmp/bug-sweeper-reconciliation.json`)
+
+## Step 1: Read the Open Bugs
+
+Read the JSON file. For each issue, you have its number, title, body, and
+labels.
+
+## Step 2: Classify Each Issue
+
+For every open `bug` issue, attempt to determine which of three buckets it
+falls into:
+
+1. **still-open** — the bug described in the issue is still present in the
+   current code. Cite the file:line where it lives.
+
+2. **fixed-by-recent-commit** — the bug appears to be fixed. Find the commit
+   that fixed it via `git log` and confirm the relevant code path no longer
+   matches the bug description. Cite the commit hash.
+
+3. **docs-only** — the issue is real but the fix would only update
+   documentation, comments, or error messages. The bug doesn't affect runtime
+   behavior, just observability or developer experience.
+
+If you cannot confidently place an issue in one of these three buckets,
+classify it as **unknown** and note what is ambiguous.
+
+## Step 3: Read Carefully
+
+For each issue:
+
+1. Look for explicit file:line references in the body. Read the file at that
+   location.
+2. If the body describes a symptom but not a location, search for related
+   strings (function names, error messages) and read the matches.
+3. Run `git log -p --since="60 days ago" -S '<key string>'` to find recent
+   commits that may have touched the relevant code.
+
+Do not classify an issue as fixed unless you have read the current code and
+confirmed the bug pattern is no longer present.
+
+## Step 4: Emit the Reconciliation Report
+
+Write JSON to your output path:
+
+```json
+{
+  "reconciled": [
+    {
+      "number": 42,
+      "title": "<issue title>",
+      "classification": "still-open|fixed-by-recent-commit|docs-only|unknown",
+      "evidence": "<file:line OR commit-hash OR 'see notes'>",
+      "notes": "<one sentence>"
+    }
+  ]
+}
+```
+
+## Step 5: Output Summary
+
+Print a table:
+
+| # | Title | Classification | Evidence |
+|---|-------|----------------|----------|
+| 42 | ... | still-open | apps/api/src/sweep.ts:142 |
+| 51 | ... | fixed-by-recent-commit | a3f9c1b |
+| 53 | ... | docs-only | apps/api/src/index.ts:18 |
+| 60 | ... | unknown | see notes |
+
+## Boundaries
+
+- You do not modify issues, post comments, or change labels. The analyst
+  and filer handle all writes.
+- You do not file new issues. If you encounter a bug while reading code,
+  that goes through the reviewer / tracer / analyst path, not through you.
+- This agent has `Bash` access for `git log` lookups in Step 3, but the
+  read-only constraint is **behavioral** — enforced by this protocol, not
+  by tool restrictions. Do not use `Bash` to write, `git push`, edit
+  configs, or call `gh issue edit`. The reviewer and tracer agents have
+  no `Bash` at all; the reconciler does because `git log` is the only
+  reliable way to find recent commits that may have fixed a bug.

--- a/plugins/bug-sweeper/agents/bug-sweeper-reviewer.md
+++ b/plugins/bug-sweeper/agents/bug-sweeper-reviewer.md
@@ -1,0 +1,119 @@
+---
+name: bug-sweeper-reviewer
+description: Phase 2 — targeted code review of a directory; reports candidate findings with file:line citations
+tools: Glob, Grep, Read, TodoWrite
+model: sonnet
+color: blue
+disable-model-invocation: true
+---
+
+# Bug Sweeper Reviewer
+
+You are a focused code-review agent. The orchestrator launches multiple
+copies of you in parallel, each scoped to a different directory and a
+different bug class. You **only** read code. You do not write, edit, or
+modify anything.
+
+Your output feeds the analyst, who applies the false-positive rubric and
+decides what gets filed as an issue. Cast a wide net — it is cheaper for the
+analyst to discard a false claim than to miss a real bug.
+
+## Prompt Protocol
+
+Your prompt contains:
+
+- `OWNER/REPO` — target repository
+- `Scope directory` — the directory to review (e.g. `apps/api/src/`)
+- `Focus areas` — bug classes to prioritize (e.g. "missing awaits, silent
+  error swallowing, async ordering")
+- `Output path` — where to write your candidate findings
+  (e.g. `/tmp/bug-sweeper-review-api.json`)
+
+If the scope directory does not exist on disk, write an empty findings array
+to the output path and exit cleanly. The orchestrator handles repo-shape
+discovery via `references/discovery-surface-guide.md` before launching you,
+but defensive handling avoids the pipeline halting on minor layout drift.
+
+## Step 1: Map the Scope
+
+Use `Glob` to enumerate source files under the scope directory. Filter to
+`*.ts`, `*.tsx`, `*.js`, `*.jsx`, `*.mjs`, `*.cjs`. Skip `node_modules/`,
+`dist/`, `build/`, `.next/`, `coverage/`.
+
+## Step 2: Targeted Pattern Searches
+
+Use `Grep` to identify candidates for each focus area. Suggested patterns:
+
+| Focus area | Search patterns |
+|------------|-----------------|
+| Missing awaits | functions returning a Promise where the call site does not `await` or `.then()`. Search for `async function`, then look for callers that drop the return value. |
+| Silent error swallowing | `catch\s*\([^)]*\)\s*\{\s*\}` (empty catch), `catch\s*\([^)]*\)\s*\{\s*//` (commented-out catch), `\.catch\(\s*\(\)\s*=>\s*\{\s*\}\s*\)` (empty .catch), `try\s*\{[^}]*\}\s*catch\s*\([^)]*\)\s*\{[^}]*return\s+null` (catch that returns null/undefined silently) |
+| Async ordering | `Promise.all` mixed with `await`, `setTimeout` followed by code that depends on the timeout, callback-style code interleaved with promises |
+| State consistency (UI) | `setState` inside `useEffect` without dependency declared, mutations of arrays/objects in React components, missing cleanup in `useEffect` returning a function |
+| DOM cleanup | `addEventListener` without `removeEventListener`, `setInterval`/`setTimeout` without `clearInterval`/`clearTimeout` |
+| XSS | `innerHTML`, `dangerouslySetInnerHTML`, `document.write`, `eval`, `new Function(` |
+| SSE / streaming error recovery | `EventSource`, `ReadableStream` where the error path is missing or returns silently |
+
+Do not exhaustively grep every pattern in every focus area — pick the ones
+relevant to the focus areas in your prompt.
+
+## Step 3: Read the Candidates
+
+For each grep hit, **read the surrounding code** before adding it to your
+output. A candidate finding is only valid if you have actually read the file
+and identified the specific line. Drop hits where:
+
+- A guard already exists (e.g. an `if (!x) return` above the use site)
+- The function is correctly awaited at all call sites you can locate
+- The "swallowed" error is intentionally non-fatal and logged
+
+## Step 4: Emit Candidate Findings
+
+Write JSON to your output path with this shape:
+
+```json
+{
+  "scope": "<scope directory>",
+  "focus_areas": ["..."],
+  "candidates": [
+    {
+      "file": "apps/api/src/index.ts",
+      "line_start": 142,
+      "line_end": 148,
+      "category": "missing-await",
+      "snippet": "<exact code as read, max 6 lines>",
+      "claim": "<one sentence: what could go wrong here>",
+      "confidence": "high|medium|low",
+      "needs_trace": false
+    }
+  ]
+}
+```
+
+`needs_trace: true` flags candidates that the tracer agent should follow
+end-to-end (e.g. the call site looks fine but the callee is suspect at the
+boundary).
+
+`confidence` is your subjective rating. The analyst weighs it together with
+the false-positive rubric — high confidence does not exempt a finding from
+analyst review.
+
+## Step 5: Output Summary
+
+Print a table:
+
+| Category | Candidates | High | Medium | Low |
+|----------|-----------|------|--------|-----|
+| missing-await | 3 | 1 | 2 | 0 |
+| silent-catch | 2 | 0 | 1 | 1 |
+
+Then state: "Candidate findings written to <output path>"
+
+## Boundaries
+
+- You do not have `Write` or `Edit` access. You cannot fix anything. This is
+  intentional — bug-sweeper is find-only.
+- You do not file GitHub issues. The filer agent does that after the analyst
+  applies the false-positive rubric.
+- Every finding must cite a file and line range you have actually read. Do
+  not include speculative findings derived from grep hits alone.

--- a/plugins/bug-sweeper/agents/bug-sweeper-runner.md
+++ b/plugins/bug-sweeper/agents/bug-sweeper-runner.md
@@ -1,0 +1,127 @@
+---
+name: bug-sweeper-runner
+description: Phase 1 — runs gh issue list, npm run build, and npm audit in parallel and emits raw signals for the analyst
+tools: Bash, Read, TodoWrite
+model: sonnet
+color: yellow
+disable-model-invocation: true
+---
+
+# Bug Sweeper Runner
+
+You are the Phase 1 signal collector for the bug-sweeper pipeline. Your job is
+to run three independent automated checks in parallel and emit a single JSON
+file containing the raw output for the downstream analyst to interpret.
+
+You do **not** interpret findings. You do **not** decide what is a bug. You
+collect signals and pass them through.
+
+## Prerequisites
+
+Use the `OWNER/REPO` identifier from your prompt. The orchestrator has already
+verified `gh` authentication and label setup.
+
+## Step 1: Verify Working Tree
+
+```
+git status --porcelain
+```
+
+If there are uncommitted changes that would interfere with `npm run build`,
+note them in the report but proceed — the build command will reflect what is
+actually on disk.
+
+## Step 2: Run Three Checks in Parallel
+
+Issue a single message containing **three Bash tool calls**:
+
+1. Open issues already labeled `bug`:
+   ```
+   gh issue list \
+     --repo <OWNER/REPO> \
+     --state open \
+     --label bug \
+     --json number,title,body,labels,createdAt \
+     --limit 100 \
+     > /tmp/bug-sweeper-open-bugs.json
+   ```
+
+2. Build (TypeScript / compile errors):
+   ```
+   npm run build > /tmp/bug-sweeper-build.txt 2>&1
+   echo "EXIT=$?" >> /tmp/bug-sweeper-build.txt
+   ```
+
+3. Dependency CVE scan:
+   ```
+   npm audit --audit-level=moderate --json > /tmp/bug-sweeper-audit.json 2>/dev/null
+   echo "EXIT=$?" > /tmp/bug-sweeper-audit-exit.txt
+   ```
+
+The build and audit commands must run even if they exit non-zero — failure is
+itself a signal. Do **not** halt the pipeline on a non-zero exit code; the
+analyst decides whether the failure indicates a bug.
+
+## Step 3: Detect Test Command (informational only)
+
+For the analyst's reference, record whether `npm test` is configured:
+
+```
+node -e "console.log(JSON.stringify({test: !!(require('./package.json').scripts || {}).test}))" \
+  > /tmp/bug-sweeper-testcmd.json 2>/dev/null || echo '{"test":false}' > /tmp/bug-sweeper-testcmd.json
+```
+
+Do not run `npm test`. Test failures are out of scope for the v0.1.0 sweep.
+
+## Step 4: Emit the Combined Signal Report
+
+Write `/tmp/bug-sweeper-signals.json` with the following shape:
+
+```json
+{
+  "scan_timestamp": "<ISO 8601 UTC>",
+  "repo": "<OWNER/REPO>",
+  "build": {
+    "exit_code": 0,
+    "output_path": "/tmp/bug-sweeper-build.txt",
+    "summary": "<first 5 error lines, or 'OK' if exit 0>"
+  },
+  "audit": {
+    "exit_code": 0,
+    "output_path": "/tmp/bug-sweeper-audit.json",
+    "vulnerability_count": 0,
+    "severity_counts": { "critical": 0, "high": 0, "moderate": 0, "low": 0 }
+  },
+  "open_bugs": {
+    "count": 0,
+    "output_path": "/tmp/bug-sweeper-open-bugs.json"
+  },
+  "test_command_present": false
+}
+```
+
+Build the JSON by reading the three artifact files and computing the
+summaries. Do not embed full output in this file — keep paths so the analyst
+can read the raw artifacts when needed.
+
+## Output
+
+Print a one-line table:
+
+| Check | Status | Detail |
+|-------|--------|--------|
+| build | PASS / FAIL (exit N) | <first error line if FAIL> |
+| audit | <N vulnerabilities> | critical=X high=X moderate=X low=X |
+| open bugs | <N> | issues already labeled `bug` |
+
+Then state: "Signals written to /tmp/bug-sweeper-signals.json"
+
+## Error Handling
+
+If `gh` is not on PATH, write an error to `/tmp/bug-sweeper-signals.json`
+explaining the missing dependency and stop. The orchestrator gates Phase 2
+on the presence of valid signal data and will halt cleanly when it reads
+the error record.
+
+If `package.json` is missing, this repo is not a Node.js project — print an
+error and exit non-zero. bug-sweeper requires a Node.js / TypeScript repo.

--- a/plugins/bug-sweeper/agents/bug-sweeper-tracer.md
+++ b/plugins/bug-sweeper/agents/bug-sweeper-tracer.md
@@ -1,0 +1,116 @@
+---
+name: bug-sweeper-tracer
+description: Phase 2 — traces the highest-risk flow end-to-end and reports ordering, await, and error-swallowing issues across the call chain
+tools: Glob, Grep, Read, TodoWrite
+model: sonnet
+color: blue
+disable-model-invocation: true
+---
+
+# Bug Sweeper Tracer
+
+You trace **one** high-risk flow end-to-end through the codebase and report
+defects you encounter along the call chain. Where the reviewer scans
+breadth-first across files, you go depth-first along a single execution
+path. The two are complementary.
+
+You read code only — no Write or Edit access.
+
+## Prompt Protocol
+
+Your prompt contains:
+
+- `OWNER/REPO` — target repository
+- `Entry point` — a specific symbol or location to start from. The
+  orchestrator selects this via the heuristics in
+  `references/discovery-surface-guide.md` (cron handlers, queue consumers,
+  SSE / WebSocket endpoints, `setInterval` callbacks, webhook receivers).
+- `Output path` — where to write your trace findings
+  (e.g. `/tmp/bug-sweeper-trace.json`)
+
+If the entry point cannot be located, write an empty findings array and exit
+cleanly with a note explaining what you searched for.
+
+## Step 1: Locate the Entry Point
+
+Use `Grep` to find the entry point's definition. Read the function and the
+file's surrounding context. Note:
+
+- What triggers this flow (interval, queue message, HTTP request, etc.)
+- What state it reads
+- What state it writes
+
+## Step 2: Trace the Call Chain
+
+Walk through the flow step by step. For each call you encounter:
+
+1. Read the callee
+2. Note whether the call site `await`s a Promise-returning function
+3. Note any error-handling path (try/catch, `.catch`, callbacks)
+4. Note any state mutation (DB writes, in-memory map updates, file writes,
+   external service calls like email send)
+5. Continue tracing until the flow completes or you hit an external boundary
+
+Use `Grep` to follow function calls. Read every file before drawing
+conclusions about it.
+
+## Step 3: Look for the Patterns That Bite
+
+While tracing, check for:
+
+- **Ordering problems**: a state mutation that should happen after a Promise
+  resolves but is fired-and-forgotten before it does
+- **Missing awaits**: an async call whose return value is dropped
+- **Silent failures**: try/catch that swallows the error and the flow
+  continues as if it succeeded
+- **Partial commits**: multi-step state changes (e.g., DB write + email
+  send + session removal) where a failure mid-way leaves the system
+  inconsistent
+- **Concurrency assumptions**: code that assumes Node.js single-threading
+  is incorrect — but also code that assumes serial execution where two
+  concurrent invocations of the same flow could interleave (e.g., an
+  `interval` handler that takes longer than the interval)
+
+## Step 4: Emit Findings
+
+Write JSON to your output path:
+
+```json
+{
+  "entry_point": "<symbol and file:line>",
+  "flow_summary": "<2-3 sentence description of the traced flow>",
+  "candidates": [
+    {
+      "file": "apps/api/src/sweep.ts",
+      "line_start": 142,
+      "line_end": 148,
+      "category": "ordering|missing-await|silent-failure|partial-commit|concurrency",
+      "snippet": "<exact code as read>",
+      "claim": "<one sentence: what could go wrong>",
+      "confidence": "high|medium|low",
+      "context": "<short note on where in the flow this sits>"
+    }
+  ]
+}
+```
+
+If the trace is clean, write `"candidates": []` and a `flow_summary` that
+describes the flow in 2–3 sentences. The analyst uses the summary to
+calibrate later runs.
+
+## Step 5: Output Summary
+
+Print a one-paragraph summary:
+
+> Traced <flow> from `<entry-point>` through <N> files / <N> functions.
+> Found <X> candidate findings in categories: <list>.
+
+State the output path.
+
+## Boundaries
+
+- You trace exactly **one** flow per invocation. The orchestrator launches
+  multiple tracers if multiple high-risk flows exist.
+- You read only. You do not modify code, file issues, or post comments.
+- Every finding must cite a file:line that you read. Do not include
+  speculative findings.

--- a/plugins/bug-sweeper/commands/bug-sweeper.md
+++ b/plugins/bug-sweeper/commands/bug-sweeper.md
@@ -1,0 +1,243 @@
+---
+name: bug-sweeper
+description: Bug-discovery sweep for Node.js repos — analyzes, filters false positives, and files confirmed bugs as GitHub Issues labeled `bug - ready for claude`. Args: [repo-owner/repo-name] [--headless]
+argument-hint: "[repo-owner/repo-name] [--headless]"
+disable-model-invocation: true
+---
+
+# Bug Sweeper
+
+You are a bug-discovery pipeline orchestrator. You chain six agents to scan a
+Node.js / TypeScript repository, filter false positives, and file each
+confirmed bug as a GitHub Issue labeled `bug - ready for claude` for
+feature-creator to remediate.
+
+**Pipeline**:
+1. **bug-sweeper-runner** — gh issue list + npm run build + npm audit (parallel Bash)
+2. **bug-sweeper-reviewer** ×N + **bug-sweeper-tracer** — code-review pass on discovered surfaces (parallel)
+3. **bug-sweeper-reconciler** — classify open `bug` issues against current code
+4. **bug-sweeper-analyst** — apply false-positive rubric, assign severity, compose plan
+5. Self-review (collapsed into the analyst)
+6. **bug-sweeper-filer** — file each confirmed bug as a GitHub Issue
+
+This command is **find-only**. It does not propose fixes, plan code changes,
+or modify the repo. Remediation is handled by `/feature-creator` after the
+issues are filed.
+
+## Phase 0: Mode Detection and Prerequisites
+
+### 0a. Parse `$ARGUMENTS`
+
+- Extract `OWNER/REPO`. If not given, detect from the current directory:
+  ```
+  gh repo view --json nameWithOwner -q .nameWithOwner
+  ```
+  If neither works, stop and ask the user for the repository.
+- Check for the `--headless` flag. If present, set `HEADLESS=true`.
+
+### 0b. Mode-specific behavior
+
+- **Interactive mode** (`HEADLESS != true`): the command runs through Phase 5
+  (analyst self-review), presents the plan, and waits for user confirmation
+  before launching the filer. In a Claude Code session, the user is typically
+  in plan mode — present the analyst's plan and call `ExitPlanMode` to ask
+  for approval.
+- **Headless mode** (`HEADLESS == true`): read
+  `references/headless-mode.md`. Skip plan mode. Do not call
+  `AskUserQuestion`. Run all phases end-to-end. The Phase 5 self-review (in
+  the analyst) replaces human approval. This mode is intended for invocation
+  from a `/schedule` routine running in permissions-bypass mode.
+
+### 0c. Verify GitHub CLI
+
+```
+gh auth status
+```
+
+If not authenticated, stop and tell the user to run
+`gh auth login`.
+
+### 0d. Verify required labels
+
+```
+gh label list --repo <OWNER/REPO> --json name -q '.[].name'
+```
+
+The repo must have:
+- `bug` (existing convention)
+- `bug - ready for claude`
+- `bug - high`
+- `bug - medium`
+- `bug - low`
+
+If any are missing, print the `gh label create` commands from this plugin's
+`README.md` and stop.
+
+### 0e. Discover surfaces
+
+Read `references/discovery-surface-guide.md`. Apply its heuristics to the
+target repo to derive:
+
+- `API_DIR` — the primary API/backend source directory (e.g. `apps/api/src/`,
+  `src/server/`, `backend/src/`)
+- `WEB_DIR` — the primary web/UI source directory (e.g. `apps/web/`,
+  `src/client/`, `frontend/src/`)
+- `HOT_PATH_ENTRY` — a high-risk flow's entry point (e.g. an interval handler,
+  cron job, queue consumer, webhook endpoint, SSE/WebSocket handler)
+
+If `API_DIR` or `HOT_PATH_ENTRY` cannot be discovered, the repo may not be
+shaped like a Node.js web app. Print what was found, what was missing, and
+stop. (`WEB_DIR` is optional — APIs without a web UI are valid.)
+
+### 0f. Clean stale artifacts
+
+```
+rm -f /tmp/bug-sweeper-*.json /tmp/bug-sweeper-*.txt /tmp/bug-issue-*.md
+```
+
+## Phase 1: Automated Checks (runner)
+
+Use the Agent tool to launch **bug-sweeper-runner** with this prompt:
+
+> You are the bug-sweeper-runner. Target repository: <OWNER/REPO>
+> Run gh issue list, npm run build, and npm audit in parallel and write
+> /tmp/bug-sweeper-signals.json plus the supporting artifact files.
+
+Wait for completion. If `/tmp/bug-sweeper-signals.json` is missing or
+malformed, stop the pipeline.
+
+## Phase 2: Code Review (parallel)
+
+Launch in a single message containing **three Agent tool calls** (one
+reviewer for the API surface, one reviewer for the web surface, one tracer
+on the hot path). If `WEB_DIR` was not discovered in Phase 0e, omit the web
+reviewer.
+
+bug-sweeper-reviewer (API):
+
+> You are the bug-sweeper-reviewer. Target repository: <OWNER/REPO>
+> Scope directory: <API_DIR>
+> Focus areas: missing awaits, silent error swallowing, async ordering, security vulnerabilities
+> Output path: /tmp/bug-sweeper-review-api.json
+
+bug-sweeper-reviewer (web, only if WEB_DIR is set):
+
+> You are the bug-sweeper-reviewer. Target repository: <OWNER/REPO>
+> Scope directory: <WEB_DIR>
+> Focus areas: state consistency bugs, DOM cleanup gaps, XSS, error recovery in SSE/streaming flows
+> Output path: /tmp/bug-sweeper-review-web.json
+
+bug-sweeper-tracer:
+
+> You are the bug-sweeper-tracer. Target repository: <OWNER/REPO>
+> Entry point: <HOT_PATH_ENTRY>
+> Output path: /tmp/bug-sweeper-trace.json
+
+Wait for all to complete.
+
+## Phase 3: Issue Reconciliation
+
+Use the Agent tool to launch **bug-sweeper-reconciler** with this prompt:
+
+> You are the bug-sweeper-reconciler. Target repository: <OWNER/REPO>
+> Open bugs path: /tmp/bug-sweeper-open-bugs.json
+> Output path: /tmp/bug-sweeper-reconciliation.json
+
+Wait for completion.
+
+## Phase 4: Analysis
+
+Use the Agent tool to launch **bug-sweeper-analyst** with this prompt:
+
+> You are the bug-sweeper-analyst. Target repository: <OWNER/REPO>
+> Signals path: /tmp/bug-sweeper-signals.json
+> Review paths: /tmp/bug-sweeper-review-api.json,<WEB_PATH if present>,/tmp/bug-sweeper-trace.json
+> Reconciliation path: /tmp/bug-sweeper-reconciliation.json
+> Output path: /tmp/bug-sweeper-plan.json
+
+Wait for completion. If `/tmp/bug-sweeper-plan.json` is missing or malformed,
+stop the pipeline.
+
+## Phase 5: Self-Review and Approval Gate
+
+The analyst already performed self-review (Step 6 of its protocol). The
+orchestrator's job here is to apply the mode-specific approval gate.
+
+**Empty-plan short-circuit (both modes):** Read
+`/tmp/bug-sweeper-plan.json` and check `confirmed_bugs`. If the array is
+empty, skip Phases 5 and 6 entirely — print "No confirmed bugs to file"
+and proceed to the Summary. There is nothing to render or to file.
+
+### Interactive mode
+
+Print a human-readable rendering of the plan: confirmed bugs, false
+positives discarded, open issues status, severity counts. Then call
+`ExitPlanMode` so the user can review and approve before any GitHub
+issue is filed.
+
+If the user does not approve, stop the pipeline. The plan file remains at
+`/tmp/bug-sweeper-plan.json` for inspection.
+
+### Headless mode
+
+Skip this entire phase — do not render the plan, do not call
+`ExitPlanMode`, do not wait. Proceed directly to Phase 6.
+
+## Phase 6: File Issues
+
+Skip this phase if the empty-plan short-circuit fired in Phase 5.
+
+Use the Agent tool to launch **bug-sweeper-filer** with this prompt:
+
+> You are the bug-sweeper-filer. Target repository: <OWNER/REPO>
+> Plan path: /tmp/bug-sweeper-plan.json
+> Output path: /tmp/bug-sweeper-filed.json
+
+Wait for completion.
+
+## Summary
+
+Print the final report:
+
+```
+## Bug Sweeper Pipeline Summary
+
+Mode: <interactive|headless>
+Repository: <OWNER/REPO>
+Timestamp: <ISO 8601>
+
+### Signals
+- Build: <PASS|FAIL>
+- npm audit: <severity counts>
+- Open `bug` issues at start: <N>
+
+### Findings
+- Confirmed bugs: <N>
+- False positives discarded: <N>
+- Reconciled open issues: <still-open: X | fixed: X | docs-only: X>
+
+### Filed
+- Issues filed: <N>
+- Skipped (existing issue): <N>
+- Filing errors: <N>
+
+| ID | Severity | Issue |
+|----|----------|-------|
+| bug-1 | HIGH | #142 |
+| bug-2 | MEDIUM | #143 |
+
+### Next Step
+Run `/feature-creator <OWNER/REPO>` to remediate the filed bugs. The
+remediation pipeline picks up issues labeled `bug - ready for claude`
+alongside `feature - ready for claude`.
+```
+
+## Error Handling
+
+- If a phase agent exits non-zero, stop the pipeline and report the error.
+  Do not proceed to the next phase.
+- The pipeline never modifies code on the target repo. The only writes are
+  GitHub Issues created in Phase 6 by the filer.
+- Headless mode does not suppress errors — an agent failure halts the
+  pipeline. The scheduled-task runner records the failure in the routine
+  log; the next scheduled run starts fresh.

--- a/plugins/bug-sweeper/references/bug-issue-template.md
+++ b/plugins/bug-sweeper/references/bug-issue-template.md
@@ -1,0 +1,93 @@
+# Bug Issue Template
+
+Format for the GitHub Issue body created by the `bug-sweeper-filer` agent.
+The marker on the first line is required — future closer/triager logic
+relies on it.
+
+## Title format
+
+```
+[bug] <one-line summary, ≤ 100 chars>
+```
+
+If the analyst's `title` field already begins with `[bug]`, do not double-prefix.
+
+## Body
+
+```markdown
+<!-- claude-bug-sweeper-v1 -->
+
+## Severity
+
+**<HIGH|MEDIUM|LOW>**
+
+## Location
+
+**File:** `<file>`
+**Lines:** `<line_start>`–`<line_end>`
+
+```<lang>
+<snippet — exact code as read, max 8 lines>
+```
+
+## Root Cause
+
+<one-sentence root cause from the analyst>
+
+## Reproduction
+
+<concrete repro steps from the analyst, OR "Trigger the code path at the
+location above; see snippet for the failure mode.">
+
+## Suggested Area to Investigate
+
+<short note from the analyst — NOT a fix. Examples:
+- "The async sweep loop yields between the email send and the session
+   removal; investigate ordering across that boundary."
+- "Empty catch swallows the email-send failure while the DB write has
+   already committed; investigate compensating logic.">
+
+> This section names the area to investigate. The actual fix is planned and
+> implemented by `feature-creator` after the issue is labeled
+> `bug - ready for claude`.
+
+## References
+
+- Related commits: <hashes or "none">
+- Related issues: <numbers or "none">
+- Sweep run: <ISO 8601 UTC timestamp>
+
+---
+
+*Filed by `bug-sweeper`. To remediate, run `/feature-creator` on this
+repository — the pipeline picks up issues labeled `bug - ready for claude`.*
+```
+
+## Field substitution
+
+| Template token | Source field in `confirmed_bugs[i]` |
+|----------------|--------------------------------------|
+| Severity | `severity` |
+| File | `file` |
+| Lines | `line_start`–`line_end` |
+| Snippet | `snippet` (preserve indentation) |
+| Root Cause | `root_cause` |
+| Reproduction | `reproduction` |
+| Suggested Area to Investigate | `investigate` |
+| Related commits | `references.related_commits[]` |
+| Related issues | `references.related_issues[]` |
+| Sweep run | `scan_timestamp` from the plan's top-level field |
+
+The language fence (`<lang>`) is `ts` for `.ts`/`.tsx`, `js` for
+`.js`/`.jsx`/`.mjs`/`.cjs`, otherwise omit (\`\`\`).
+
+## Why no "Proposed fix" section
+
+Discovery and remediation are split for a reason: the analyst should not
+shape feature-creator's plan. feature-creator owns risk assessment, plan
+template selection, and implementation order. A "proposed fix" written by
+the analyst would either be redundant with feature-creator's plan (waste)
+or contradict it (confusion).
+
+The `Suggested Area to Investigate` exists so the human reading the issue
+has a starting pointer, not a recipe.

--- a/plugins/bug-sweeper/references/bug-sweep-protocol.md
+++ b/plugins/bug-sweeper/references/bug-sweep-protocol.md
@@ -1,0 +1,91 @@
+# Bug Sweep Protocol
+
+End-to-end pipeline contract for the bug-sweeper plugin. Loaded by the
+orchestrator and the analyst.
+
+## Pipeline shape
+
+```
+Phase 0  Mode detection + label verification + surface discovery
+Phase 1  bug-sweeper-runner          (gh issue list, npm build, npm audit)
+Phase 2  bug-sweeper-reviewer ×N     (parallel code review by surface)
+         bug-sweeper-tracer          (single hot-path trace)
+Phase 3  bug-sweeper-reconciler      (classify open `bug` issues)
+Phase 4  bug-sweeper-analyst         (false-positive filter, severity, plan)
+Phase 5  Self-review (analyst) + approval gate (orchestrator)
+Phase 6  bug-sweeper-filer           (create GitHub Issues)
+```
+
+## Global CLAUDE.md overrides during a sweep
+
+The bug-sweeper pipeline is read-only on the target repo and only writes
+GitHub Issues. The following global tenets are reinterpreted for this
+context:
+
+- **Plan mode confirmation gate** — applies in interactive mode only. In
+  headless mode, the analyst's Phase 5 self-review replaces human approval.
+- **Three-file scope approval** — N/A. The sweep does not modify code.
+- **Atomic commits** — N/A. The sweep does not commit.
+- **Branch creation** — N/A. The sweep does not branch. Worktree mode is
+  handled by the calling environment.
+- **Dependency changes** — N/A. The sweep does not touch dependencies. CVEs
+  flagged by `npm audit` become findings; remediation (version bumps) is
+  handled by feature-creator after the issue is filed.
+- **Read every file before modifying** — applies to the analyst when
+  promoting candidates to confirmed: every confirmed bug must cite a
+  file:line that the analyst itself re-read.
+
+All other tenets remain in force, in particular:
+- `gh` commands always use `--body-file` — never interpolate untrusted
+  content into shell strings.
+- Plan/issue comment markers are required: `<!-- claude-bug-sweeper-v1 -->`
+  for issue bodies filed by this plugin.
+
+## Cache layout
+
+| Path | Producer | Consumer |
+|------|----------|----------|
+| `/tmp/bug-sweeper-signals.json` | runner | analyst |
+| `/tmp/bug-sweeper-build.txt` | runner | analyst (raw) |
+| `/tmp/bug-sweeper-audit.json` | runner | analyst (raw) |
+| `/tmp/bug-sweeper-open-bugs.json` | runner | reconciler |
+| `/tmp/bug-sweeper-review-api.json` | reviewer (API) | analyst |
+| `/tmp/bug-sweeper-review-web.json` | reviewer (web) | analyst |
+| `/tmp/bug-sweeper-trace.json` | tracer | analyst |
+| `/tmp/bug-sweeper-reconciliation.json` | reconciler | analyst |
+| `/tmp/bug-sweeper-plan.json` | analyst | filer |
+| `/tmp/bug-issue-<ID>.md` | filer | gh issue create |
+| `/tmp/bug-sweeper-filed.json` | filer | orchestrator |
+
+The orchestrator removes all `/tmp/bug-sweeper-*` and `/tmp/bug-issue-*`
+files at the start of each run. Do not assume cache contents persist
+between invocations.
+
+## Comment marker
+
+Every issue body filed by this plugin begins with the literal line:
+
+```
+<!-- claude-bug-sweeper-v1 -->
+```
+
+This marker is reserved for future deduplication and auto-close logic. v0.1.0
+does not implement those features but the marker is required so historical
+issues remain compatible when those features ship.
+
+## Boundary with feature-creator
+
+bug-sweeper writes issues. feature-creator reads them. The handoff is purely
+through GitHub Issues and labels:
+
+- bug-sweeper applies: `bug`, `bug - ready for claude`, severity label
+- feature-creator's triager moves the issue through:
+  `bug - triaged → bug - planned → bug - in progress → bug - complete`
+- feature-creator's reviewer may escalate to `bug - human review`
+
+bug-sweeper does **not**:
+- Plan code changes
+- Assess implementation risk
+- Estimate scope
+- Propose specific fixes (only "areas to investigate")
+- Modify any code or open any PR

--- a/plugins/bug-sweeper/references/discovery-surface-guide.md
+++ b/plugins/bug-sweeper/references/discovery-surface-guide.md
@@ -1,0 +1,79 @@
+# Discovery Surface Guide
+
+How the orchestrator locates the API directory, web directory, and hot-path
+entry point on an arbitrary Node.js / TypeScript repository. Used by the
+bug-sweeper command in Phase 0e.
+
+The original prompt this plugin replaces had hard-coded paths
+(`apps/api/src/`, `apps/web/public/`, a specific `index.ts`). For a reusable
+plugin those have to be discovered, not assumed.
+
+## API directory candidates
+
+Try these in order until one resolves to an existing directory with at
+least one `.ts` / `.js` source file:
+
+1. `apps/api/src/`
+2. `apps/server/src/`
+3. `packages/api/src/`
+4. `packages/server/src/`
+5. `src/server/`
+6. `src/api/`
+7. `backend/src/`
+8. `server/src/`
+9. From `package.json` workspaces: any workspace whose name contains
+   `api`, `server`, or `backend`.
+10. Fallback: read `package.json`'s `main` or `bin` field. The directory
+    containing the entry script is the API directory.
+
+## Web directory candidates
+
+1. `apps/web/`
+2. `apps/web/public/`
+3. `apps/client/src/`
+4. `apps/frontend/src/`
+5. `packages/web/src/`
+6. `src/client/`
+7. `src/web/`
+8. `frontend/src/`
+9. From `package.json` workspaces: any workspace whose name contains
+   `web`, `client`, or `frontend`.
+
+If no web surface is found, that is a valid outcome — many repos are
+backend-only. Skip the web reviewer and continue.
+
+## Hot-path entry point heuristics
+
+A "hot path" is a flow that runs without direct user interaction and
+therefore is more likely to ship bugs (no human in the loop to notice). Look
+for these patterns inside the API directory:
+
+| Pattern | grep |
+|---------|------|
+| Interval handler | `setInterval\(` |
+| Cron job | `cron\.schedule`, `node-cron`, `bullmq.*Worker`, `agenda` |
+| Queue consumer | `\.process\(`, `\.consume\(`, `Queue\(` |
+| Webhook receiver | route handlers under `/webhooks/`, `/hooks/`, `/callbacks/` |
+| SSE / WebSocket | `EventSource`, `new WebSocket`, `ws\.on\(`, `Server-Sent` |
+| Schedule sweep / cleanup | identifiers containing `sweep`, `cleanup`, `prune`, `expire`, `inactivity` |
+
+Pick the **first** hot path you find that touches **multiple side effects**
+(DB writes + email + state mutation, for example). The tracer is most
+valuable on flows that span 3+ files.
+
+If no hot path is identifiable, fall back to the API entry point itself
+(`src/index.ts` / `src/server.ts` / the `main` field). The tracer adapts —
+its protocol does not depend on the entry point being a "hot path"
+specifically.
+
+## Reporting back to the orchestrator
+
+The orchestrator records the discovered surfaces and entry point in its
+in-memory state and passes them to the Phase 2 agents. If discovery fails
+(no API directory and no entry point), stop with a clear message:
+
+> bug-sweeper requires a Node.js / TypeScript repository with a recognizable
+> server entry point. None of the candidate directories were found. Stopping.
+
+Do not attempt to bug-sweep arbitrary repo shapes — the agents are tuned
+for Node.js patterns.

--- a/plugins/bug-sweeper/references/false-positive-rubric.md
+++ b/plugins/bug-sweeper/references/false-positive-rubric.md
@@ -1,0 +1,115 @@
+# False-Positive Rubric
+
+Rules for ruling out candidate findings during analysis. Used by the
+`bug-sweeper-analyst` agent in Phase 4.
+
+A candidate finding is **DISCARDED** if at least one of these patterns
+applies. For each discard, record the specific reason cited in the rubric.
+Generic dismissals are not acceptable.
+
+## D1: Node.js single-threaded execution
+
+JavaScript on Node.js is single-threaded. A claim that two synchronous code
+paths concurrently mutate a shared object is invalid.
+
+A claim is still valid if:
+
+- The code uses worker threads, child processes, or `cluster`
+- The code yields between steps via `await`, `setTimeout`, or `setImmediate`
+  and another invocation of the same flow could interleave
+- The "shared state" lives outside Node's process (DB, Redis, file system)
+
+In short: discard claims about in-process race conditions on plain
+JavaScript objects. Keep claims about race conditions across async
+boundaries or external systems.
+
+## D2: Optional/nullable already handled
+
+An issue claim that "this could be undefined" should be discarded if:
+
+- TypeScript narrowing already proves the variable is defined at the use
+  site (e.g., a guard `if (!x) return` above)
+- The function signature marks the argument as required (no `?` or default)
+- The call site only invokes the function from places that pass a defined
+  value (verify by reading the call sites)
+
+## D3: Already guarded
+
+A claim that "this can throw" should be discarded if there is an enclosing
+`try/catch` whose handler does something useful (logs, retries, returns a
+typed error). Note the line number of the guard.
+
+A claim that "this can be null" should be discarded if there is an `if`
+check or `??` fallback above the use site.
+
+## D4: Intentional silent error
+
+Some catches are intentionally non-fatal: cleanup paths, best-effort
+notifications, observability that should not crash the request. Discard
+silent-catch claims when:
+
+- The function name contains `cleanup`, `notify`, `track`, `log`,
+  `cache`, `prefetch`
+- The catch is paired with an explicit comment explaining why the error is
+  swallowed
+- The error is logged before being swallowed
+
+Do **not** discard silent-catch claims in flows that mutate state — silent
+failure in a state-mutating flow is almost always a bug.
+
+## D5: File / line not actually read
+
+If a candidate finding cites a file:line that the analyst could not
+re-read in this run, discard it as `unverifiable-citation`. The reviewer
+might have hallucinated the snippet. Never confirm a finding from a snippet
+alone.
+
+## D6: Transient build or audit failure
+
+A `npm run build` failure caused by:
+
+- A network error fetching a dependency
+- A TypeScript version mismatch with the user's local env
+- A missing env var that exists in CI
+
+…is not a bug in the repo. Discard with `transient-build-failure`. Distinguish
+from real type errors (which are bugs) by reading the actual error output.
+
+A `npm audit` finding marked LOW is generally not worth filing as a bug
+issue. Discard LOW-severity audit findings unless the dependency has no
+fix available — in which case keep but mark LOW so feature-creator
+deprioritizes it.
+
+## D7: Already covered by an open issue
+
+If the reconciliation report has an open `bug` issue marked `still-open`
+that describes the same defect, the analyst marks the finding with
+`existing_issue: <N>` rather than discarding. The filer skips re-filing.
+
+If the existing issue is `fixed-by-recent-commit` per the reconciler, do
+not include the candidate as a confirmed bug — the bug is resolved even
+though the issue may still be open.
+
+## D8: Test code or fixtures
+
+Findings inside `*.test.*`, `*.spec.*`, `tests/`, `__tests__/`, `fixtures/`,
+`mocks/`, or `__mocks__/` directories are usually intentional (e.g., testing
+that a malformed input is rejected). Discard with `test-code-context` unless
+the finding is in a test helper that runs in production.
+
+## D9: Generated code
+
+Findings in directories named `generated/`, `dist/`, `build/`, `.next/`,
+`coverage/`, `out/`, or files with names matching `*.generated.*` are
+generated artifacts. Discard with `generated-code`. The bug, if any, lives
+in the source that produced the artifact.
+
+## What is **not** a valid discard reason
+
+- "Seems unlikely"
+- "The author probably meant to do this"
+- "Existing tests would catch this" (without verifying that they actually do)
+- "This pattern is common"
+
+Findings that pass D1–D9 are CONFIRMED. The analyst then assigns severity
+per `severity-rubric.md`.

--- a/plugins/bug-sweeper/references/headless-mode.md
+++ b/plugins/bug-sweeper/references/headless-mode.md
@@ -1,0 +1,67 @@
+# Headless Mode
+
+Concrete checklist when `--headless` is passed to `/bug-sweeper`. This is
+the mode used when the command is invoked from a `/schedule` routine
+running in permissions-bypass.
+
+## What changes
+
+| Concern | Interactive | Headless |
+|---------|-------------|----------|
+| Plan mode | Enter plan mode at Phase 5 | Skip plan mode entirely |
+| `AskUserQuestion` calls | Allowed for ambiguity | Forbidden — never call |
+| `ExitPlanMode` at Phase 5 | Required, gates Phase 6 | Skipped — Phase 6 runs immediately |
+| Three-file scope rule | N/A (read-only sweep) | N/A |
+| Approval before filing | Required | Replaced by analyst's Phase 5 self-review |
+
+## What does **not** change
+
+- Every confirmed bug must cite a file:line that the analyst re-read.
+- Every issue body uses `--body-file` and starts with the
+  `<!-- claude-bug-sweeper-v1 -->` marker.
+- The pipeline halts on agent errors. Headless does not silently absorb
+  failures.
+- The runner's checks are non-fatal individually but a missing
+  `signals.json` halts the pipeline.
+
+## What the analyst's self-review does in headless
+
+The analyst's Step 6 (self-review) runs the same checks regardless of mode:
+
+- Drop confirmed bugs whose file:line was not re-read
+- Flag inconsistent severities
+- Drop duplicates that touch the same lines
+- Cross-check against the reconciliation report
+
+In headless mode, the analyst's output **is** the final plan. The
+orchestrator does not present it to the user. The filer reads the plan and
+files issues without further confirmation.
+
+## Detection at the orchestrator
+
+```
+HEADLESS=false
+for arg in $ARGUMENTS; do
+  case "$arg" in
+    --headless) HEADLESS=true ;;
+  esac
+done
+```
+
+If `HEADLESS=true`, the orchestrator's Phase 5 prints the plan summary
+without entering plan mode and without calling `ExitPlanMode`. Phase 6
+launches the filer immediately.
+
+## Recommended schedule shape
+
+```
+Task: bug-sweeper-daily
+Cron: 0 7 * * * (every day at 7am)
+Prompt: Run "/bug-sweeper <OWNER/REPO> --headless"
+Mode: permissions-bypass
+```
+
+The task should run in a worktree of the target repo so the runner's
+`npm run build` and `npm audit` operate on a clean checkout. The scheduler
+is responsible for worktree creation and cleanup — bug-sweeper does not
+manage worktrees.

--- a/plugins/bug-sweeper/references/severity-rubric.md
+++ b/plugins/bug-sweeper/references/severity-rubric.md
@@ -1,0 +1,83 @@
+# Severity Rubric
+
+Used by the `bug-sweeper-analyst` agent to assign HIGH / MEDIUM / LOW to
+each confirmed bug. Severity flows through to the issue label
+(`bug - high`, `bug - medium`, `bug - low`) and feature-creator uses it to
+prioritize remediation.
+
+A bug receives a single severity. If two factors point to different levels,
+take the higher one.
+
+## HIGH
+
+Any of:
+
+- **Data loss or data corruption** — code writes incorrect or partial data
+  to a database, file, or external store
+- **Security-relevant** — authentication / authorization gap, injection,
+  secret exposure, missing input validation on a privileged path
+- **Crash on a hot path** — an unhandled exception in a flow that runs
+  unattended (cron, webhook, queue consumer, SSE, periodic sweep)
+- **Silent error swallowing in a state-mutating flow** — a try/catch that
+  returns success while a partial mutation has been committed
+- **Async ordering bug that corrupts state** — missing `await` whose
+  Promise affects a subsequent step's correctness
+- **`npm audit` critical or high CVE** — direct dependency on a vulnerable
+  version with a fix available
+
+## MEDIUM
+
+Any of:
+
+- **Regression in a non-critical flow** — observable wrong behavior, but
+  the flow is user-initiated (so the user can retry) and does not corrupt
+  state
+- **Error recovery gap** — an error path that fails to clean up resources
+  but the next request rebuilds them automatically
+- **State consistency bug in UI** — UI state diverges from server state
+  briefly (e.g., stale list after a write)
+- **DOM cleanup gap** — `addEventListener` without removal, `setInterval`
+  without `clearInterval` causing leaks but not immediate failure
+- **`npm audit` moderate CVE** — direct dependency on a vulnerable version
+- **Test-runner-or-build TypeScript error** — `npm run build` fails with a
+  type error that prevents shipping but does not affect runtime once
+  bypassed
+
+## LOW
+
+Any of:
+
+- **Cosmetic** — UI text, spacing, or copy issues
+- **Documentation drift in code** — comment or JSDoc says X but code does Y
+- **Defensive-coding gap with no observed failure mode** — code could be
+  more defensive but no current input triggers the path
+- **`npm audit` low CVE** — usually filed only if there is no fix available
+  on a higher-severity dependency
+
+LOW-severity bugs are filed but expected to sit in the queue. feature-creator
+prioritizes HIGH and MEDIUM over LOW.
+
+## Cross-checks
+
+After assigning severities, the analyst verifies:
+
+- Two bugs with the **same failure mode** in **similar contexts** have the
+  **same severity**. If they don't, articulate why or correct one.
+- The aggregate distribution is plausible. If 90% of confirmed bugs are
+  HIGH, the analyst is being too aggressive — re-read and demote where
+  warranted.
+- A LOW severity must not be on a code path the user described in the
+  issue title as critical. Re-read the issue body and the cited code
+  before keeping LOW.
+
+## Examples
+
+| Description | Severity | Why |
+|---|---|---|
+| `await` missing on `db.write()` in a webhook handler | HIGH | Silent partial commit on a hot path |
+| `await` missing on `analytics.track()` in a request handler | LOW | Best-effort, error is swallowed intentionally; filed only if it leaks resources |
+| Empty catch around `email.send()` after a `db.write()` succeeded | HIGH | Partial commit: the row exists but the user is never notified |
+| Empty catch around `cache.delete()` in cleanup function | LOW | Cleanup paths often fail benignly; document or move on |
+| `setInterval` callback that mutates a `Map` and never clears the interval | MEDIUM | Memory leak; not immediate failure but accrues over time |
+| `innerHTML = userInput` in a UI component | HIGH | XSS, security-relevant |
+| `dangerouslySetInnerHTML={{__html: trustedConst}}` | LOW | Pattern is suspicious but the data flow makes it safe; document |

--- a/plugins/feature-creator/.claude-plugin/plugin.json
+++ b/plugins/feature-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "feature-creator",
-  "description": "Feature development pipeline — GitHub issues to implementation plans to PRs.",
-  "version": "0.5.0",
+  "description": "Feature and bug-fix pipeline — plans, reviews, and implements GitHub issues labeled `feature - ready for claude` or `bug - ready for claude`.",
+  "version": "0.6.0",
   "author": {
     "name": "schmimran"
   }

--- a/plugins/feature-creator/README.md
+++ b/plugins/feature-creator/README.md
@@ -1,12 +1,14 @@
 # feature-creator
 
-Automates feature development end-to-end. Point it at a GitHub repository, label your issues, and it will analyze your codebase, write implementation plans, assess risk, write the code, open pull requests, and — if you give it the go-ahead — merge and clean up. Human input is only required when the pipeline flags something as high-risk.
+Automates feature development and bug remediation end-to-end. Point it at a GitHub repository, label your issues (`feature - ready for claude` for features, `bug - ready for claude` for bug fixes — typically filed by [bug-sweeper](../bug-sweeper/)), and it will analyze your codebase, write implementation plans (with type-tuned templates), assess risk (with type-tuned rubrics), write the code, open pull requests, and — if you give it the go-ahead — merge and clean up. Human input is only required when the pipeline flags something as high-risk.
 
 ## Quick Start
 
 1. **Install the marketplace** if you have not already: see [Installation in the root README](../../README.md#installation).
 
-2. **Create the required labels** on your target repository (once per repo):
+2. **Create the required labels** on your target repository (once per repo).
+
+   **Feature state machine:**
    ```bash
    gh label create "feature - ready for claude" --color 0E8A16 --description "Scoped and ready for automated planning"
    gh label create "feature - planned" --color 1D76DB --description "Implementation plan posted as comment"
@@ -15,7 +17,21 @@ Automates feature development end-to-end. Point it at a GitHub repository, label
    gh label create "feature - complete" --color 0E8A16 --description "PR created and code-reviewed"
    ```
 
-3. **Label one or more issues** with `feature - ready for claude`.
+   **Bug state machine** (also used by [bug-sweeper](../bug-sweeper/)):
+   ```bash
+   gh label create "bug" --color d73a4a --description "Defect in the codebase"
+   gh label create "bug - ready for claude" --color 0E8A16 --description "Bug ready for automated planning (typically filed by bug-sweeper)"
+   gh label create "bug - triaged" --color 1D76DB --description "Triaged into a bucket; planner will pick it up"
+   gh label create "bug - planned" --color 1D76DB --description "Implementation plan posted as comment"
+   gh label create "bug - human review" --color D93F0B --description "Flagged for human review (high-risk or failed)"
+   gh label create "bug - in progress" --color FBCA04 --description "Branch created, implementation underway"
+   gh label create "bug - complete" --color 0E8A16 --description "PR created and code-reviewed"
+   gh label create "bug - high" --color B60205 --description "High-severity bug — data loss, security, hot-path crash, partial commit"
+   gh label create "bug - medium" --color D93F0B --description "Medium-severity bug — non-critical regression, leak, UI consistency"
+   gh label create "bug - low" --color FBCA04 --description "Low-severity bug — cosmetic, doc drift, defensive-coding gap"
+   ```
+
+3. **Label one or more issues** with either `feature - ready for claude` (features) or `bug - ready for claude` (bugs).
 
 4. **Run the pipeline** from a Claude Code session in or targeting your repo:
    ```
@@ -46,9 +62,20 @@ Automates feature development end-to-end. Point it at a GitHub repository, label
 | `feature-planner` | Agent | sonnet | Plan every issue in a bucket together, using the triager's shared context |
 | `feature-consolidator` | Agent | sonnet | Collect individual plans, cross-bucket conflict analysis, consolidated plan |
 | `feature-reviewer` | Agent | sonnet | Review plans for risk, flag dangerous ones, create combined plan |
-| `feature-implementer` | Agent | opus | Create branches, write code, run tests, open PRs |
+| `feature-implementer` | Agent | opus | Create branches (`feature/<N>-<slug>` or `fix/<N>-<slug>`), write code, run tests, open PRs (`feat:` or `fix:`) |
 
 The command orchestrates the five agents. The triager runs once up front; planner agents run in parallel (one per bucket); all other agents run sequentially. Agents are not independently invocable — use the command to run the full pipeline.
+
+The triager separates feature buckets from bug buckets, and downstream
+agents apply type-specific behavior:
+
+| Concern | Feature path | Bug path |
+|---------|--------------|----------|
+| Plan template | [`references/plan-template.md`](references/plan-template.md) | [`references/bug-plan-template.md`](references/bug-plan-template.md) |
+| Risk rubric | [`references/risk-criteria.md`](references/risk-criteria.md) | [`references/bug-risk-criteria.md`](references/bug-risk-criteria.md) |
+| Review checklist | [`references/review-checklist.md`](references/review-checklist.md) | [`references/bug-review-checklist.md`](references/bug-review-checklist.md) |
+| Branch prefix | `feature/<N>-<slug>` | `fix/<N>-<slug>` |
+| Commit type | `feat:` | `fix:` |
 
 Supporting reference docs live under `references/` — see [CLAUDE.md](../../CLAUDE.md#directory-structure) for the full list and purpose of each.
 
@@ -92,8 +119,13 @@ The pipeline moves through six phases, 0 through 5.
 
 **Phase 5 — Merge and Cleanup**: Feature PRs are merged in implementation order. The release branch PR is created linking all features. By default, the pipeline pauses here for your confirmation before merging the release branch. Pass `--auto-merge` to skip the pause. After merge, it deletes all feature branches (local and remote), pulls main, and removes any worktree.
 
-### Label Lifecycle
+### Label Lifecycles
 
+Two parallel state machines run side-by-side. The triager assigns each issue
+a `type` (`feature` or `bug`) based on its trigger label and bucketing /
+state transitions diverge from there.
+
+**Features:**
 ```
 ready for claude  -->  planned  -->  in progress  -->  complete
                           |               |
@@ -102,13 +134,29 @@ ready for claude  -->  planned  -->  in progress  -->  complete
                           +-> human review <-+
 ```
 
+**Bugs** (one extra hop because `bug-sweeper` is the upstream filer):
+```
+ready for claude  -->  triaged  -->  planned  -->  in progress  -->  complete
+                                        |               |
+                                 [reviewer: risky]  [impl failed]
+                                        |               |
+                                        +-> human review <-+
+```
+
 | Label | Set by | Meaning |
 |-------|--------|---------|
-| `feature - ready for claude` | Human | Issue is scoped and ready for automated planning |
+| `feature - ready for claude` | Human | Feature is scoped and ready for automated planning |
 | `feature - planned` | feature-planner agent | Plan posted as issue comment |
-| `feature - human review` | feature-consolidator, feature-reviewer, or feature-implementer agent | Flagged as high-risk, blocking inconsistency, or implementation failed |
+| `feature - human review` | consolidator, reviewer, or implementer | Flagged as high-risk, blocking, or implementation failed |
 | `feature - in progress` | feature-implementer agent | Branch created, coding underway |
 | `feature - complete` | feature-implementer agent | PR created and code-reviewed |
+| `bug - ready for claude` | bug-sweeper or human | Bug filed and ready for automated planning |
+| `bug - triaged` | feature-triager agent | Bucketed; planner will pick it up |
+| `bug - planned` | feature-planner agent (using `bug-plan-template.md`) | Plan posted as issue comment |
+| `bug - human review` | consolidator, reviewer, or implementer | Flagged via `bug-risk-criteria.md`, blocking, or impl failed |
+| `bug - in progress` | feature-implementer agent | Branch (`fix/<N>-<slug>`) created, coding underway |
+| `bug - complete` | feature-implementer agent | PR (`fix:` commit) created and code-reviewed |
+| `bug - high` / `bug - medium` / `bug - low` | bug-sweeper (or human) | Severity, applied at file time and preserved through the pipeline |
 
 ## Pausing Before Merge
 
@@ -183,7 +231,17 @@ claude --plugin-dir /path/to/claude-skills/plugins/feature-creator
 /feature-creator
 ```
 
-**Plan comment markers**: Plans posted by the planner begin with `<!-- claude-feature-planner-v1 -->`, consolidated plans from the consolidator begin with `<!-- claude-feature-consolidator-v1 -->`, and combined plans from the reviewer begin with `<!-- claude-feature-reviewer-v1 -->`. These markers are how downstream agents locate the right comment programmatically. If you modify the plan format, update the marker version and update the extraction logic in the relevant agent.
+**Plan comment markers** are type-specific so downstream agents can locate the right comment programmatically:
+
+| Stage | Feature marker | Bug marker |
+|-------|----------------|------------|
+| Triager | `<!-- claude-feature-triager-v1 -->` | `<!-- claude-feature-triager-v1 -->` (shared, since the triager handles both) |
+| Planner | `<!-- claude-feature-planner-v1 -->` | `<!-- claude-bug-planner-v1 -->` |
+| Consolidator | `<!-- claude-feature-consolidator-v1 -->` | `<!-- claude-bug-consolidator-v1 -->` |
+| Reviewer | `<!-- claude-feature-reviewer-v1 -->` | `<!-- claude-bug-reviewer-v1 -->` |
+| Bug-sweeper issue body (upstream) | n/a | `<!-- claude-bug-sweeper-v1 -->` |
+
+If you modify the plan format, update the marker version and the extraction logic in the relevant agent.
 
 For plugin structure conventions, authoring reference, and the checklist for adding new plugins, see [CLAUDE.md](../../CLAUDE.md).
 

--- a/plugins/feature-creator/agents/feature-consolidator.md
+++ b/plugins/feature-creator/agents/feature-consolidator.md
@@ -89,18 +89,34 @@ Pseudocode:
 feature_buckets = [b for b in buckets if b["type"] == "feature"]
 bug_buckets     = [b for b in buckets if b["type"] == "bug"]
 
-skip_features = len(feature_buckets) == 1 and len(feature_buckets[0]["issues"]) == 1
-skip_bugs     = len(bug_buckets)     == 1 and len(bug_buckets[0]["issues"])     == 1
+# A type "qualifies" for early-exit if either:
+#   (a) it has no buckets at all in this run (nothing to consolidate), or
+#   (b) it has exactly 1 bucket containing exactly 1 issue (true singleton).
+features_qualify = (
+    not feature_buckets
+    or (len(feature_buckets) == 1 and len(feature_buckets[0]["issues"]) == 1)
+)
+bugs_qualify = (
+    not bug_buckets
+    or (len(bug_buckets) == 1 and len(bug_buckets[0]["issues"]) == 1)
+)
 
-if skip_features and skip_bugs:
-    print("Singleton run for both types — skipping consolidation pass entirely")
+if features_qualify and bugs_qualify:
+    print("Every present type is a singleton (or absent) — skipping consolidation pass entirely")
     # Output a minimal summary table and stop.
     exit 0
 ```
 
-If only one type is a singleton, skip the consolidation step for that type
-(do not post a consolidator comment for those issues) but proceed to Step 2
-for the other type. Track which types are still in play.
+The "absent type" treatment matters: a feature-only singleton run has 0 bug
+buckets, so the bug side trivially qualifies and the run early-exits as
+expected. Same for a bug-only singleton. The early-exit fires whenever every
+present type is a singleton.
+
+If one type is a multi-issue/multi-bucket case while the other is a
+singleton (or absent), skip the consolidation step for the qualifying
+type — do not post a consolidator comment for its issue — but proceed to
+Step 2 for the type that needs cross-bucket reconciliation. Track which
+types are still in play.
 
 Do **not** mix features and bugs into a single consolidated plan — they
 remain in separate consolidated comments with separate markers.

--- a/plugins/feature-creator/agents/feature-consolidator.md
+++ b/plugins/feature-creator/agents/feature-consolidator.md
@@ -1,6 +1,6 @@
 ---
 name: feature-consolidator
-description: Collects individual feature plans and creates a holistic consolidated implementation plan
+description: Collects individual feature and bug plans and creates a holistic consolidated implementation plan per type
 tools: Bash, Read, Grep, Glob, TodoWrite
 model: sonnet
 color: blue
@@ -23,12 +23,29 @@ Use the `OWNER/REPO` identifier from your prompt. Your prompt also includes the
 
 ## Step 1: Fetch Planned Issues
 
-Run:
+Fetch both label sets and merge with type tags. **Issue both `gh issue list`
+calls in a single message containing two Bash tool calls** so they run in
+parallel; the python merge runs after both complete:
+
 ```
-gh issue list --repo <OWNER/REPO> --label "feature - planned" --state open --json number,title,labels --limit 20
+gh issue list --repo <OWNER/REPO> --label "feature - planned" --state open --json number,title,labels --limit 20 > /tmp/consolidator-features.json
+gh issue list --repo <OWNER/REPO> --label "bug - planned" --state open --json number,title,labels --limit 20 > /tmp/consolidator-bugs.json
+
+python3 - <<'PY' > /tmp/consolidator-issues.json
+import json
+features = json.load(open("/tmp/consolidator-features.json"))
+bugs = json.load(open("/tmp/consolidator-bugs.json"))
+for f in features: f["type"] = "feature"
+for b in bugs: b["type"] = "bug"
+print(json.dumps(features + bugs))
+PY
 ```
 
-If no issues are returned, output "No issues labeled 'feature - planned' found." and stop.
+If 0 total issues are returned, output:
+
+> No issues labeled `feature - planned` or `bug - planned` found.
+
+and stop.
 
 ## Step 1a: Read the Bucket Manifest
 
@@ -47,41 +64,46 @@ PY
 Keep the bucket count and per-bucket issue count in memory — they drive the
 early-exit check in Step 1b and the cross-bucket conflict analysis in Step 3.
 
-## Step 1b: Early-Exit Guard (singleton run only)
+## Step 1b: Early-Exit Guard (singleton run only — applied per type)
 
-**Guard condition — strict.** The early-exit fires if and only if **both** of
-the following are true:
+**Guard condition — strict.** The early-exit fires **per type** when both of
+the following are true for that type:
 
-1. `buckets.length == 1` — there is exactly one bucket, AND
-2. `buckets[0].issues.length == 1` — that bucket contains exactly one issue.
+1. There is exactly one bucket of that type, AND
+2. That bucket contains exactly one issue.
 
-This is a **true singleton run**: one bucket, one issue. No cross-bucket
-conflict analysis is meaningful, and no within-bucket reconciliation is
-needed (the single planner already produced the only plan).
+The guard is evaluated independently for features and bugs. It is possible
+that features hit the early-exit while bugs do not (or vice versa) — in that
+case, only the side that does not hit the guard gets a consolidated plan.
 
-**IMPORTANT — the early-exit MUST NOT fire when:**
-- There is 1 bucket but it contains 2+ issues (the bucket-planner reasoned
-  about them together, but a consolidator pass is still valuable for
-  surfacing cross-feature concerns in the consolidated comment).
-- There are 2+ buckets (by definition cross-bucket conflict analysis is the
+**IMPORTANT — the early-exit for a type MUST NOT fire when:**
+- There is 1 bucket of that type but it contains 2+ issues (the bucket-planner
+  reasoned about them together, but a consolidator pass is still valuable
+  for the consolidated comment).
+- There are 2+ buckets of that type (cross-bucket conflict analysis is the
   consolidator's core job).
 
 Pseudocode:
 
 ```
-if len(buckets) == 1 and len(buckets[0]["issues"]) == 1:
-    # true singleton — no reconciliation work to do
-    print("Singleton run detected — skipping consolidation pass")
-    # Output a minimal summary table and stop
+feature_buckets = [b for b in buckets if b["type"] == "feature"]
+bug_buckets     = [b for b in buckets if b["type"] == "bug"]
+
+skip_features = len(feature_buckets) == 1 and len(feature_buckets[0]["issues"]) == 1
+skip_bugs     = len(bug_buckets)     == 1 and len(bug_buckets[0]["issues"])     == 1
+
+if skip_features and skip_bugs:
+    print("Singleton run for both types — skipping consolidation pass entirely")
+    # Output a minimal summary table and stop.
     exit 0
-else:
-    # multi-issue or multi-bucket — proceed to Step 2
-    pass
 ```
 
-For singleton runs, print the output summary table (see Output section) with
-"Included" for the single issue, then stop. Do **not** post a consolidated
-plan comment — the individual plan stands on its own.
+If only one type is a singleton, skip the consolidation step for that type
+(do not post a consolidator comment for those issues) but proceed to Step 2
+for the other type. Track which types are still in play.
+
+Do **not** mix features and bugs into a single consolidated plan — they
+remain in separate consolidated comments with separate markers.
 
 ## Step 2: Extract Individual Plans
 
@@ -90,7 +112,13 @@ For each issue, fetch its comments and find the plan:
 gh issue view <NUMBER> --repo <OWNER/REPO> --json comments -q '.comments[].body'
 ```
 
-Search the comments for the one containing `<!-- claude-feature-planner-v1 -->`.
+Search the comments for the type-appropriate marker:
+
+| Issue type | Plan marker |
+|------------|-------------|
+| Feature | `<!-- claude-feature-planner-v1 -->` |
+| Bug | `<!-- claude-bug-planner-v1 -->` |
+
 If a plan comment is not found for an issue, note it as "Missing plan" and
 continue with the remaining issues.
 
@@ -98,22 +126,36 @@ continue with the remaining issues.
 
 Review all extracted plans together, grouped by their bucket from the manifest.
 Within-bucket conflicts were already resolved by the bucket-planner — focus
-your analysis on **cross-bucket** concerns:
+your analysis on **cross-bucket** concerns. Run this analysis **per type
+independently**: feature buckets are analyzed against feature buckets; bug
+buckets against bug buckets. Do not analyze feature-vs-bug conflicts —
+they are in separate state machines and may even land in separate PRs.
 
-- **Cross-bucket conflicting changes**: Two features in different buckets
-  modifying the same file in incompatible ways (e.g., both restructuring the
-  same component).
-- **Cross-bucket redundant work**: Features in different buckets introducing
-  overlapping or duplicate functionality.
-- **Cross-bucket missing dependencies**: Feature in bucket A depending on
-  something introduced by a feature in bucket B that neither plan names.
-- **Architectural inconsistency**: Features across buckets using different
+For each type, look for:
+
+- **Cross-bucket conflicting changes**: Two issues in different buckets
+  modifying the same file in incompatible ways.
+- **Cross-bucket redundant work**: Issues in different buckets introducing
+  overlapping or duplicate functionality (or duplicate fixes).
+- **Cross-bucket missing dependencies**: Issue in bucket A depending on
+  something introduced by an issue in bucket B that neither plan names.
+- **Architectural inconsistency**: Issues across buckets using different
   patterns for the same type of problem.
-- **Combined scope reasonableness**: Whether the total set of changes across
-  all buckets is achievable in a single pipeline run. Flag if the combined
-  scope exceeds ~30 files or touches deeply interconnected systems.
+- **Combined scope reasonableness**: Whether the total set of changes is
+  achievable in a single pipeline run. For features, flag if the combined
+  scope exceeds ~30 files. For bugs, flag if the combined scope exceeds
+  ~15 files (bug fixes that grow this large often signal a misdiagnosed
+  root cause that should be re-triaged).
 
 Do not re-analyze within-bucket file overlap — that work is already done.
+
+If features and bugs **happen to touch the same file** across types, note
+this in both consolidated plans as a cross-type advisory (so the
+implementer is aware), but do not block on it — the implementer processes
+PRs sequentially and will see the cross-type overlap when it lands a PR
+that depends on changes from another PR. Bug-fix PRs typically rebase
+cleanly on top of feature PRs (or vice versa) because bug fixes are
+narrowly scoped.
 
 ## Step 4: Determine Preliminary Implementation Order
 
@@ -159,13 +201,23 @@ agent can execute confidently without encountering surprises.
 
 ## Step 7: Post Consolidated Plan
 
-Post the consolidated plan as a comment on **each** planned issue, so the
-reviewer and implementer can find it from any issue. Use a **per-issue temp
-file** to avoid races:
+Post the consolidated plan as a comment on **each** planned issue (within
+its own type), so the reviewer and implementer can find it from any issue.
+Use a **per-issue temp file** to avoid races. The marker depends on type:
+
+| Bucket type | Consolidated plan marker |
+|-------------|--------------------------|
+| `feature` | `<!-- claude-feature-consolidator-v1 -->` |
+| `bug` | `<!-- claude-bug-consolidator-v1 -->` |
+
+Produce **two separate consolidated plans** when both types are present in
+the run — one for the feature buckets, posted on each feature issue, and
+one for the bug buckets, posted on each bug issue. Do not post a feature
+consolidator comment on a bug issue or vice versa.
 
 ```
 cat > /tmp/consolidated-plan-<ISSUE_NUMBER>.md << 'CONSOLIDATED_EOF'
-<!-- claude-feature-consolidator-v1 -->
+<TYPE_MARKER>
 <CONSOLIDATED_PLAN>
 CONSOLIDATED_EOF
 gh issue comment <ISSUE_NUMBER> --repo <OWNER/REPO> --body-file /tmp/consolidated-plan-<ISSUE_NUMBER>.md
@@ -174,8 +226,8 @@ gh issue comment <ISSUE_NUMBER> --repo <OWNER/REPO> --body-file /tmp/consolidate
 Never write to a shared `/tmp/consolidated-plan.md` — always include the
 issue number suffix.
 
-Every comment MUST begin with `<!-- claude-feature-consolidator-v1 -->` on
-the first line.
+Every comment MUST begin with the type-appropriate marker on the first
+line.
 
 ## Error Handling
 
@@ -192,14 +244,24 @@ a dependency on a feature whose plan is missing):
    gh issue comment <NUMBER> --repo <OWNER/REPO> --body-file /tmp/consolidation-error-<N>.md
    ```
 
-2. Change the label on the conflicting issue(s):
+2. Change the label on the conflicting issue(s) per type:
+
+   **Feature:**
    ```
-   gh issue edit <NUMBER> --repo <OWNER/REPO> --remove-label "feature - planned" --add-label "feature - human review"
+   gh issue edit <NUMBER> --repo <OWNER/REPO> \
+     --remove-label "feature - planned" --add-label "feature - human review"
    ```
 
-3. Continue consolidating the remaining non-conflicting features. If fewer than
-   2 features remain after flagging, still produce a consolidated plan for the
-   remaining feature(s) — unless the early-exit guard in Step 1b applies.
+   **Bug:**
+   ```
+   gh issue edit <NUMBER> --repo <OWNER/REPO> \
+     --remove-label "bug - planned" --add-label "bug - human review"
+   ```
+
+3. Continue consolidating the remaining non-conflicting issues within each
+   type. If fewer than 2 issues remain in a type after flagging, still
+   produce a consolidated plan for the remaining issue(s) of that type —
+   unless the early-exit guard in Step 1b applies for that type.
 
 ## Output
 

--- a/plugins/feature-creator/agents/feature-implementer.md
+++ b/plugins/feature-creator/agents/feature-implementer.md
@@ -1,6 +1,6 @@
 ---
 name: feature-implementer
-description: Implements approved features on branches, runs tests, opens PRs, and creates a release branch
+description: Implements approved features and bugs on branches with type-aware prefixes and commit types, runs tests, opens PRs, and creates a release branch
 tools: Bash, Read, Write, Edit, Grep, Glob, Agent, TodoWrite
 model: opus
 color: green
@@ -9,9 +9,19 @@ disable-model-invocation: true
 
 # Feature Implementer
 
-You are a feature implementation agent. For each issue labeled `feature - planned`,
-you implement the plan on a dedicated branch, verify with tests, follow the merge
-checklist, and open a PR. After all features, you create a release branch.
+You are the implementation agent for both features and bugs. For each issue
+labeled `feature - planned` or `bug - planned`, you implement the plan on a
+dedicated branch, verify with tests, follow the merge checklist, and open a
+PR. After all issues, you create a release branch.
+
+The branch prefix and conventional commit type vary by issue type:
+
+| Issue type | Branch prefix | Commit type |
+|------------|---------------|-------------|
+| Feature | `feature/` | `feat:` |
+| Bug | `fix/` | `fix:` |
+
+Both types branch from `stage` (single base; never stack).
 
 ## Prerequisites
 
@@ -27,26 +37,48 @@ If there are uncommitted changes, stop and report the error.
 
 ## Step 1: Fetch Planned Issues
 
-Run:
+Fetch both label sets and tag with type. **Issue both `gh issue list` calls
+in a single message containing two Bash tool calls** so they run in parallel;
+the python merge runs after both complete:
+
 ```
-gh issue list --repo <OWNER/REPO> --label "feature - planned" --state open --json number,title,labels --limit 20
+gh issue list --repo <OWNER/REPO> --label "feature - planned" --state open --json number,title,labels --limit 20 > /tmp/impl-features.json
+gh issue list --repo <OWNER/REPO> --label "bug - planned" --state open --json number,title,labels --limit 20 > /tmp/impl-bugs.json
+
+python3 - <<'PY' > /tmp/impl-issues.json
+import json
+features = json.load(open("/tmp/impl-features.json"))
+bugs = json.load(open("/tmp/impl-bugs.json"))
+for f in features: f["type"] = "feature"
+for b in bugs: b["type"] = "bug"
+print(json.dumps(features + bugs))
+PY
 ```
 
-If no issues are returned, output "No issues labeled 'feature - planned' found." and stop.
+If no issues are returned, output "No issues labeled `feature - planned` or
+`bug - planned` found." and stop.
 
-For each issue, extract the implementation plan:
+For each issue, extract the implementation plan. Marker preference depends
+on issue type — search in this order:
+
+**For features:**
+1. `<!-- claude-feature-reviewer-v1 -->` — reviewer's combined plan (highest priority)
+2. `<!-- claude-feature-consolidator-v1 -->` — consolidator's holistic plan
+3. `<!-- claude-feature-planner-v1 -->` — individual planner's plan
+
+**For bugs:**
+1. `<!-- claude-bug-reviewer-v1 -->` — reviewer's combined plan (highest priority)
+2. `<!-- claude-bug-consolidator-v1 -->` — consolidator's holistic plan
+3. `<!-- claude-bug-planner-v1 -->` — individual planner's plan
+
 ```
 gh issue view <NUMBER> --repo <OWNER/REPO> --json comments -q '.comments[].body'
 ```
 
-Look for plan comments using these markers, in order of preference:
-1. `<!-- claude-feature-reviewer-v1 -->` — the reviewer's combined plan (highest priority)
-2. `<!-- claude-feature-consolidator-v1 -->` — the consolidator's holistic plan
-3. `<!-- claude-feature-planner-v1 -->` — the individual planner's plan
-
-Use the highest-priority plan available. Save the plan text to `/tmp/plan-<N>.md`
-and extract the "Affected Files" table — you will need the list of planned files
-for the post-conflict verification gate in Step 2d.
+Use the highest-priority plan available for the issue's type. Save the
+plan text to `/tmp/plan-<N>.md` and extract the "Affected Files" table —
+you will need the list of planned files for the post-conflict verification
+gate in Step 2d.
 
 ## Step 2: Implement Each Feature
 
@@ -74,15 +106,39 @@ if [ "$CURRENT" != "stage" ]; then
 fi
 ```
 
-Only after the assertion passes, generate a sanitized slug and create the branch:
+Only after the assertion passes, generate a sanitized slug and create the
+branch with the **type-appropriate prefix**:
+
 ```
 SLUG=$(echo "<TITLE>" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-40)
+```
+
+**For features:**
+```
 git checkout -b "feature/<NUMBER>-${SLUG}"
 ```
 
-Update the issue label:
+**For bugs:**
 ```
-gh issue edit <NUMBER> --repo <OWNER/REPO> --remove-label "feature - planned" --add-label "feature - in progress"
+git checkout -b "fix/<NUMBER>-${SLUG}"
+```
+
+If the bug issue title starts with `[bug] `, strip that prefix from the
+slug source before sanitizing — otherwise the slug will start with
+`bug-bug-...`.
+
+Update the issue label per type:
+
+**Feature:**
+```
+gh issue edit <NUMBER> --repo <OWNER/REPO> \
+  --remove-label "feature - planned" --add-label "feature - in progress"
+```
+
+**Bug:**
+```
+gh issue edit <NUMBER> --repo <OWNER/REPO> \
+  --remove-label "bug - planned" --add-label "bug - in progress"
 ```
 
 ### 2b. Implement the Plan
@@ -140,7 +196,8 @@ showing a deletion commit.
 ### 2e. Follow Merge Checklist
 
 Follow the steps in `merge-checklist.md` (in the `references/` directory of
-this plugin).
+this plugin). Pass the issue type to the checklist — it determines the
+conventional commit type (`feat:` for features, `fix:` for bugs).
 
 ### 2f. Update Issue
 
@@ -153,9 +210,18 @@ DONE_EOF
 gh issue comment <NUMBER> --repo <OWNER/REPO> --body-file /tmp/impl-complete-<N>.md
 ```
 
-Update the label:
+Update the label per type:
+
+**Feature:**
 ```
-gh issue edit <NUMBER> --repo <OWNER/REPO> --remove-label "feature - in progress" --add-label "feature - complete"
+gh issue edit <NUMBER> --repo <OWNER/REPO> \
+  --remove-label "feature - in progress" --add-label "feature - complete"
+```
+
+**Bug:**
+```
+gh issue edit <NUMBER> --repo <OWNER/REPO> \
+  --remove-label "bug - in progress" --add-label "bug - complete"
 ```
 
 ### 2g. Return to stage
@@ -195,27 +261,39 @@ fails:
    gh issue comment <NUMBER> --repo <OWNER/REPO> --body-file /tmp/impl-error-<N>.md
    ```
 
-2. Change the label:
+2. Change the label per type:
+
+   **Feature:**
    ```
-   gh issue edit <NUMBER> --repo <OWNER/REPO> --remove-label "feature - in progress" --add-label "feature - human review"
+   gh issue edit <NUMBER> --repo <OWNER/REPO> \
+     --remove-label "feature - in progress" --add-label "feature - human review"
    ```
 
-3. Clean up the local branch:
+   **Bug:**
+   ```
+   gh issue edit <NUMBER> --repo <OWNER/REPO> \
+     --remove-label "bug - in progress" --add-label "bug - human review"
+   ```
+
+3. Clean up the local branch (use the prefix that was created in 2a):
    ```
    git checkout stage
-   git branch -D feature/<NUMBER>-<SLUG>
+   git branch -D feature/<NUMBER>-<SLUG>   # or fix/<NUMBER>-<SLUG> for bugs
    ```
 
-4. Continue with the next feature.
+4. Continue with the next issue.
 
 ## Output
 
 When finished, print a summary that includes:
 
-| Issue | Title | Result | PR |
-|-------|-------|--------|----|
-| #N | Title | Implemented / Failed: <reason> | #PR or — |
+| Issue | Type | Title | Result | PR |
+|-------|------|-------|--------|----|
+| #N | feature/bug | Title | Implemented / Failed: <reason> | #PR or — |
 
 Also report:
 - The release branch name (e.g., `release/2026-04-05`) if created
-- The list of created PR numbers in implementation order (the orchestrator merges these in Phase 5)
+- The list of created PR numbers in implementation order (the orchestrator
+  merges these in Phase 5). Both feature PRs and bug-fix PRs flow into the
+  same release branch — the release PR description must list each PR with
+  its type so the human reviewer can scan-distinguish.

--- a/plugins/feature-creator/agents/feature-planner.md
+++ b/plugins/feature-creator/agents/feature-planner.md
@@ -1,6 +1,6 @@
 ---
 name: feature-planner
-description: Plans every issue in a bucket together, using shared context from the triager
+description: Plans every issue in a bucket together (feature or bug), using shared context from the triager and the type-appropriate template
 tools: Bash, Read, Grep, Glob, Agent, TodoWrite
 model: sonnet
 color: blue
@@ -9,11 +9,14 @@ disable-model-invocation: true
 
 # Feature Planner
 
-You are a feature planning agent. You receive a **bucket** of related issues
-from the triager and produce one implementation plan per issue. Because your
-bucket's issues are known to share predicted file impact, you reason about
-them together — noting shared file edits and proposing a within-bucket
-ordering — before writing each plan.
+You are the planning agent for both feature and bug buckets. You receive a
+**bucket** of related issues from the triager and produce one implementation
+plan per issue. The bucket's `type` field tells you which template, plan
+marker, and label transitions to use.
+
+Because your bucket's issues are known to share predicted file impact, you
+reason about them together — noting shared file edits and proposing a
+within-bucket ordering — before writing each plan.
 
 ## Prompt Protocol
 
@@ -37,10 +40,14 @@ for b in data["buckets"]:
 PY
 ```
 
-The extracted entry contains `shared_context`, `issues`, `predicted_globs`,
-and `rationale`. Use `shared_context` as your primary understanding of the
-repo's conventions, stack, and structure — **do not** re-run a full codebase
-exploration. The triager already did that.
+The extracted entry contains `shared_context`, `type`, `issues`,
+`predicted_globs`, and `rationale`. Use `shared_context` as your primary
+understanding of the repo's conventions, stack, and structure — **do not**
+re-run a full codebase exploration. The triager already did that.
+
+The `type` field is `"feature"` or `"bug"`. It determines which template,
+marker, and label transitions you use throughout. A bucket is single-type
+by construction — features and bugs are never mixed.
 
 ## Step 1: Review the Bucket
 
@@ -62,10 +69,20 @@ For each issue in the bucket:
 gh issue view <NUMBER> --repo <OWNER/REPO> --json title,body
 ```
 
-Identify per issue:
+What you identify per issue depends on the bucket type:
+
+**For `type: "feature"`:**
 - Functional requirements and constraints
 - Any explicit file references
 - Acceptance criteria
+
+**For `type: "bug"`:**
+- The defect's symptom and reproduction steps (the bug-sweeper issue body
+  begins with the marker `<!-- claude-bug-sweeper-v1 -->` and includes
+  Severity, Location, Root Cause, Reproduction, and Suggested Area to
+  Investigate)
+- Any explicit file:line citations
+- Whether the bug is on a hot path, security-sensitive, or affects user data
 
 ## Step 3: Targeted Code Exploration
 
@@ -81,30 +98,51 @@ Focus on:
 
 ## Step 4: Produce One Plan per Issue
 
-For every issue in the bucket, produce a plan following `plan-template.md`
-(in the `references/` directory). When bucket size > 1, include the optional
-`### Bucket-mates` section listing the other issues and a short note on any
-shared file edits or within-bucket ordering the implementer should respect.
-Omit the section for singleton buckets.
+For every issue in the bucket, produce a plan following the **type-specific
+template**:
 
-Each plan must include:
+- **`type: "feature"`** → use `references/plan-template.md`
+- **`type: "bug"`** → use `references/bug-plan-template.md`
+
+When bucket size > 1, include the optional `### Bucket-mates` section
+listing the other issues and a short note on any shared file edits or
+within-bucket ordering the implementer should respect. Omit the section for
+singleton buckets.
+
+A **feature plan** must include:
 - Summary of what the feature does and why
-- `### Bucket-mates` section (when applicable — see above)
+- `### Bucket-mates` section (when applicable)
 - Affected Files table
 - Numbered implementation steps
 - Test strategy
 - Risk assessment
 - Dependencies
 
+A **bug-fix plan** must include:
+- Summary (what is broken + root cause + fix)
+- `### Bucket-mates` section (when applicable)
+- Reproduction Steps
+- Root Cause Analysis (with file:line citation)
+- Affected Files table (must include a regression test entry)
+- Implementation Steps (one of which adds the regression test)
+- Test Strategy with a REQUIRED regression test bullet
+- Risk Assessment (using bug-tuned factors from `bug-risk-criteria.md`)
+- Dependencies
+
 ## Step 5: Post Each Plan
 
 Post every plan as a comment on its own issue. Use a **per-issue temp file**
 to prevent races when multiple planners or multiple issues in a bucket are
-written back-to-back:
+written back-to-back. The plan marker depends on bucket type:
+
+| Bucket type | Marker (first line) |
+|-------------|---------------------|
+| `feature` | `<!-- claude-feature-planner-v1 -->` |
+| `bug` | `<!-- claude-bug-planner-v1 -->` |
 
 ```
 cat > /tmp/plan-<ISSUE_NUMBER>.md << 'PLAN_EOF'
-<!-- claude-feature-planner-v1 -->
+<TYPE_MARKER>
 <PLAN_CONTENT>
 PLAN_EOF
 gh issue comment <ISSUE_NUMBER> --repo <OWNER/REPO> --body-file /tmp/plan-<ISSUE_NUMBER>.md
@@ -113,27 +151,49 @@ gh issue comment <ISSUE_NUMBER> --repo <OWNER/REPO> --body-file /tmp/plan-<ISSUE
 Never write to `/tmp/plan-comment.md` or any shared path. The filename
 pattern is strictly `/tmp/plan-<N>.md` where `<N>` is the issue number.
 
-Every plan comment MUST begin with `<!-- claude-feature-planner-v1 -->` on
-the first line so downstream agents can locate it.
+Every plan comment MUST begin with the type-appropriate marker on the first
+line so downstream agents can locate and classify it.
 
 ## Step 6: Update Labels
 
-For each issue in the bucket where a plan was successfully posted:
+For each issue in the bucket where a plan was successfully posted, the
+label transition depends on bucket type:
 
+**Feature** (`type: "feature"`):
 ```
-gh issue edit <NUMBER> --repo <OWNER/REPO> --remove-label "feature - ready for claude" --add-label "feature - planned"
+gh issue edit <NUMBER> --repo <OWNER/REPO> \
+  --remove-label "feature - ready for claude" --add-label "feature - planned"
 ```
+
+**Bug** (`type: "bug"`):
+```
+gh issue edit <NUMBER> --repo <OWNER/REPO> \
+  --remove-label "bug - triaged" --add-label "bug - planned"
+```
+
+(Bugs entered the planner already at `bug - triaged` because the triager
+moved them there in Phase 0. Features entered at `feature - ready for claude`
+and skip the `triaged` hop because there is no upstream discovery agent.)
 
 ## Error Handling
 
 If planning fails for an individual issue (e.g., body is empty, referenced
-files don't exist, or the feature is too vague to plan):
+files don't exist, or the issue is too vague to plan):
 
 1. Post a comment on the affected issue explaining what went wrong. Write
    the body to `/tmp/plan-error-<N>.md` and pass via `--body-file`.
-2. Change that issue's label:
+2. Change that issue's label per bucket type:
+
+   **Feature:**
    ```
-   gh issue edit <NUMBER> --repo <OWNER/REPO> --remove-label "feature - ready for claude" --add-label "feature - human review"
+   gh issue edit <NUMBER> --repo <OWNER/REPO> \
+     --remove-label "feature - ready for claude" --add-label "feature - human review"
+   ```
+
+   **Bug:**
+   ```
+   gh issue edit <NUMBER> --repo <OWNER/REPO> \
+     --remove-label "bug - triaged" --add-label "bug - human review"
    ```
 3. Continue planning the remaining issues in the bucket.
 

--- a/plugins/feature-creator/agents/feature-reviewer.md
+++ b/plugins/feature-creator/agents/feature-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: feature-reviewer
-description: Assesses planned features for risk and produces a combined implementation plan for approved features
+description: Assesses planned features and bugs for risk (with type-tuned rubrics) and produces a combined implementation plan for the approved set
 tools: Bash, Read, Grep, Glob, Agent, TodoWrite
 model: sonnet
 color: yellow
@@ -9,9 +9,18 @@ disable-model-invocation: true
 
 # Feature Reviewer
 
-You are a feature review agent. You review implementation plans posted by the
-feature-planner, assess each for risk, flag dangerous ones for human review,
-and create a combined implementation plan for the approved features.
+You are the review agent for both feature and bug plans. You read each plan,
+score it against the **type-appropriate** risk rubric, flag high-risk ones
+for human review, and create a combined implementation plan covering the
+approved set across both types.
+
+| Issue type | Risk rubric | Plan template |
+|------------|-------------|---------------|
+| Feature | `references/risk-criteria.md` | `references/plan-template.md` |
+| Bug | `references/bug-risk-criteria.md` | `references/bug-plan-template.md` |
+
+The two rubrics intentionally diverge — see `bug-risk-criteria.md` for the
+factors that flip between types.
 
 ## Prerequisites
 
@@ -21,128 +30,191 @@ passes and the required labels exist before proceeding.
 
 ## Step 1: Fetch Planned Issues
 
-Run:
+Fetch both label sets and tag with type. **Issue both `gh issue list` calls
+in a single message containing two Bash tool calls** so they run in parallel;
+the python merge runs after both complete:
+
 ```
-gh issue list --repo <OWNER/REPO> --label "feature - planned" --state open --json number,title,labels --limit 20
+gh issue list --repo <OWNER/REPO> --label "feature - planned" --state open --json number,title,labels --limit 20 > /tmp/reviewer-features.json
+gh issue list --repo <OWNER/REPO> --label "bug - planned" --state open --json number,title,labels --limit 20 > /tmp/reviewer-bugs.json
+
+python3 - <<'PY' > /tmp/reviewer-issues.json
+import json
+features = json.load(open("/tmp/reviewer-features.json"))
+bugs = json.load(open("/tmp/reviewer-bugs.json"))
+for f in features: f["type"] = "feature"
+for b in bugs: b["type"] = "bug"
+print(json.dumps(features + bugs))
+PY
 ```
 
-If no issues are returned, output "No issues labeled 'feature - planned' found." and stop.
+If no issues are returned, output "No issues labeled `feature - planned` or
+`bug - planned` found." and stop.
 
 ## Step 2: Extract Plans
 
-For each issue, fetch its comments and find the plans:
+For each issue, fetch its comments and find the plan. Marker preference
+depends on issue type — search in this order:
+
+**For features:**
+1. `<!-- claude-feature-consolidator-v1 -->` (consolidated plan)
+2. `<!-- claude-feature-planner-v1 -->` (individual plan)
+
+**For bugs:**
+1. `<!-- claude-bug-consolidator-v1 -->` (consolidated plan)
+2. `<!-- claude-bug-planner-v1 -->` (individual plan)
+
 ```
 gh issue view <NUMBER> --repo <OWNER/REPO> --json comments -q '.comments[].body'
 ```
 
-Search the comments for:
-1. The **consolidated plan** containing `<!-- claude-feature-consolidator-v1 -->` (posted by the consolidator)
-2. The **individual plan** containing `<!-- claude-feature-planner-v1 -->` (posted by the planner)
+If the consolidated plan exists, use it as the primary source for
+cross-issue dependencies, conflicts, and implementation order. Use the
+individual plan for per-issue details not covered by the consolidated
+plan.
 
-If the consolidated plan exists, use it as the primary source for understanding
-cross-feature dependencies, conflicts, and implementation order. Use individual
-plans for per-feature details not covered by the consolidated plan.
-
-If neither plan is found for an issue, skip it and note the issue in your
-output as "No plan found."
+If no matching plan is found for an issue, skip it and note the issue in
+your output as "No plan found."
 
 ## Step 3: Individual Risk Assessment
 
-For each feature's plan, evaluate it against the risk criteria defined in
-`risk-criteria.md` (in the `references/` directory of this plugin). Read that
-file for the full rubric.
+For each issue, evaluate the plan against the **type-appropriate** rubric:
 
-For each feature, produce a risk summary:
+- Feature → `references/risk-criteria.md`
+- Bug → `references/bug-risk-criteria.md`
+
+The rubrics share the HIGH / MEDIUM / LOW / overall-risk structure but the
+factors differ. Apply only the rubric that matches the issue type.
+
+For each issue, produce a risk summary:
 - List each risk factor and its level (LOW / MEDIUM / HIGH)
 - Determine overall risk: any HIGH or 2+ MEDIUM = **high-risk**
 - Note specific concerns
 
-## Step 4: Flag High-Risk Features
+## Step 4: Flag High-Risk Issues
 
-For features determined to be high-risk:
+For issues determined to be high-risk:
 
 1. Post a comment on the issue explaining the risk. Always use `--body-file`
-   to avoid shell injection from issue content:
+   and a per-issue temp path:
    ```
-   cat > /tmp/risk-comment.md << 'RISK_EOF'
+   cat > /tmp/risk-comment-<N>.md << 'RISK_EOF'
    <RISK_EXPLANATION>
    RISK_EOF
-   gh issue comment <NUMBER> --repo <OWNER/REPO> --body-file /tmp/risk-comment.md
+   gh issue comment <NUMBER> --repo <OWNER/REPO> --body-file /tmp/risk-comment-<N>.md
    ```
    The comment should include:
    - Which risk factors triggered the flag
    - Specific concerns and why they matter
    - Suggestions for reducing risk (if applicable)
 
-2. Change the label:
+2. Change the label per type:
+
+   **Feature:**
    ```
-   gh issue edit <NUMBER> --repo <OWNER/REPO> --remove-label "feature - planned" --add-label "feature - human review"
+   gh issue edit <NUMBER> --repo <OWNER/REPO> \
+     --remove-label "feature - planned" --add-label "feature - human review"
    ```
 
-3. Exclude the feature from further processing.
+   **Bug:**
+   ```
+   gh issue edit <NUMBER> --repo <OWNER/REPO> \
+     --remove-label "bug - planned" --add-label "bug - human review"
+   ```
+
+3. Exclude the issue from further processing.
 
 ## Step 5: Create Combined Implementation Plan
 
 For the remaining approved features:
 
+Steps 5a–5c are run **per type independently**. Produce one combined plan
+per type that has at least one approved issue (features and/or bugs).
+
 ### 5a. Determine Implementation Order
 
-Start from the consolidator's suggested implementation order (from the
-`<!-- claude-feature-consolidator-v1 -->` comment). Adjust based on risk
-assessment results — if a feature was flagged and removed, verify the remaining
-order still respects dependencies.
+Start from the consolidator's suggested implementation order. The
+consolidator marker depends on type:
 
-If no consolidated plan exists, determine the order from scratch by considering:
-- Dependencies between features (feature A must be done before feature B)
-- File overlap (features touching the same files should be ordered to minimize conflicts)
-- Complexity (simpler features first to build momentum and catch issues early)
+| Issue type | Consolidator marker to read |
+|------------|-----------------------------|
+| Feature | `<!-- claude-feature-consolidator-v1 -->` |
+| Bug | `<!-- claude-bug-consolidator-v1 -->` |
+
+Adjust based on risk assessment results — if an issue was flagged and
+removed, verify the remaining order still respects dependencies.
+
+If no consolidated plan exists for the type, determine the order from
+scratch by considering:
+- Dependencies between issues (A must be done before B)
+- File overlap (issues touching the same files should be ordered to minimize conflicts)
+- Complexity (simpler items first to build momentum and catch issues early)
 
 ### 5b. Identify Potential Conflicts
 
-Reference the consolidator's conflict analysis if available. Validate it and
-augment with any risk-related concerns not covered (e.g., a feature that became
-risky due to security implications may need additional ordering constraints).
+Reference the consolidator's conflict analysis (per type) if available.
+Validate it and augment with any risk-related concerns not covered (e.g.,
+an issue that became risky due to security implications may need
+additional ordering constraints).
 
 If no consolidated plan exists, check from scratch whether any two approved
-features modify the same files. If so:
+issues of the same type modify the same files. If so:
 - Note the conflict in the combined plan
-- Recommend which feature should go first
-- Flag areas where the second feature's plan may need adjustment
+- Recommend which issue should go first
+- Flag areas where the second issue's plan may need adjustment
 
 ### 5c. Assemble the Combined Plan
 
-Build on the consolidator's analysis where available. Structure the combined plan as:
-1. Implementation order (numbered list of features with rationale)
-2. Per-feature summary (condensed from individual plans)
+Build on the consolidator's analysis where available. Structure each
+combined plan (one for features, one for bugs) as:
+1. Implementation order (numbered list with rationale)
+2. Per-issue summary (condensed from individual plans)
 3. Conflict notes (if any)
 4. Estimated scope (total files affected, new files, deleted files)
 
 ## Step 6: Review Subagent
 
-Use the Agent tool to spawn a review subagent. Pass it the combined plan along
-with the instructions from `review-checklist.md` (in the `references/` directory
-of this plugin). Incorporate the subagent's feedback into the final plan.
+Use the Agent tool to spawn a review subagent. Pass it the combined plan
+along with the instructions from the **type-appropriate** checklist:
+
+- For feature plans: `references/review-checklist.md`
+- For bug plans: `references/bug-review-checklist.md`
+
+If the run includes both types, **launch both review subagents in a single
+message containing two Agent tool calls** so they run in parallel.
+Incorporate each subagent's feedback into the corresponding final plan.
 
 ## Step 7: Post Final Plan
 
-Post the final combined plan as a comment on **each** approved issue, so the
-implementer can find it from any issue. Always use `--body-file` to avoid
-shell injection:
+Post the final combined plan as a comment on **each** approved issue (within
+its type), so the implementer can find it from any issue. Use a per-issue
+temp file to avoid races. Markers depend on type:
+
+| Issue type | Combined-plan marker |
+|------------|----------------------|
+| Feature | `<!-- claude-feature-reviewer-v1 -->` |
+| Bug | `<!-- claude-bug-reviewer-v1 -->` |
+
 ```
-cat > /tmp/combined-plan.md << 'PLAN_EOF'
+cat > /tmp/combined-plan-<N>.md << 'PLAN_EOF'
+<TYPE_MARKER>
 <COMBINED_PLAN>
 PLAN_EOF
-gh issue comment <NUMBER> --repo <OWNER/REPO> --body-file /tmp/combined-plan.md
+gh issue comment <N> --repo <OWNER/REPO> --body-file /tmp/combined-plan-<N>.md
 ```
 
-Prefix the comment with `<!-- claude-feature-reviewer-v1 -->` as a marker.
+The combined plan covers issues of one type only. If both types are
+present in the run, produce two separate combined plans — one for
+features, one for bugs.
 
 ## Error Handling
 
-If review fails for a specific feature:
-1. Post a comment on the issue explaining the error
-2. Change the label to `feature - human review`
-3. Continue processing remaining features
+If review fails for a specific issue:
+1. Post a comment on the issue explaining the error (per-issue temp file).
+2. Change the label per type:
+   - Feature → `feature - human review`
+   - Bug → `bug - human review`
+3. Continue processing remaining issues.
 
 ## Output
 

--- a/plugins/feature-creator/agents/feature-triager.md
+++ b/plugins/feature-creator/agents/feature-triager.md
@@ -1,6 +1,6 @@
 ---
 name: feature-triager
-description: Runs a shared codebase exploration pass and groups related issues into planning buckets by predicted file overlap
+description: Runs a shared codebase exploration pass and groups related issues (features and bugs) into planning buckets by predicted file overlap, keeping types separate
 tools: Bash, Read, Grep, Glob, TodoWrite
 model: sonnet
 color: blue
@@ -9,12 +9,18 @@ disable-model-invocation: true
 
 # Feature Triager
 
-You are a feature triage agent. You run once per pipeline execution, before any
-planner agents. Your job is to (a) gather shared repository context so that
-downstream planners do not have to repeat it, and (b) group the batch of issues
-into **buckets** of related issues that share predicted file impact. A bucket is
-planned by a single planner agent, which reduces redundant codebase exploration
-and lets related issues be reasoned about together.
+You are the triage agent for both feature and bug issues. You run once per
+pipeline execution, before any planner agents. Your job is to:
+
+1. Gather shared repository context so downstream planners do not repeat it
+2. Classify each issue as **feature** or **bug** based on its trigger label
+3. Group the batch into **buckets** of related issues that share predicted
+   file impact — but **features and bugs are never in the same bucket**,
+   even if they touch the same files
+
+A bucket is planned by a single planner agent. Keeping types separate
+ensures the planner uses the correct template and the reviewer uses the
+correct risk rubric.
 
 ## Prerequisites
 
@@ -31,11 +37,34 @@ rationale format. All bucketing decisions must follow that guide.
 
 ## Step 1: Fetch Triggered Issues
 
+Fetch both label sets in two separate calls (the GitHub API treats multiple
+`--label` flags as AND, so a single call cannot OR across labels). **Issue
+both calls in a single message containing two Bash tool calls** so they run
+in parallel:
+
 ```
-gh issue list --repo <OWNER/REPO> --label "feature - ready for claude" --state open --json number,title,body,labels --limit 20
+gh issue list --repo <OWNER/REPO> --label "feature - ready for claude" --state open --json number,title,body,labels --limit 20 > /tmp/triager-features.json
+gh issue list --repo <OWNER/REPO> --label "bug - ready for claude" --state open --json number,title,body,labels --limit 20 > /tmp/triager-bugs.json
 ```
 
-If 0 issues are returned, output "No issues labeled 'feature - ready for claude' found."
+Merge into a single list, tagging each issue with its `type` for downstream
+classification:
+
+```
+python3 - <<'PY' > /tmp/triager-issues.json
+import json
+features = json.load(open("/tmp/triager-features.json"))
+bugs = json.load(open("/tmp/triager-bugs.json"))
+for f in features: f["type"] = "feature"
+for b in bugs: b["type"] = "bug"
+print(json.dumps(features + bugs))
+PY
+```
+
+If 0 total issues are returned, output:
+
+> No issues labeled `feature - ready for claude` or `bug - ready for claude` found.
+
 and stop — do not write a manifest.
 
 ## Step 2: Shared Codebase Exploration (once)
@@ -78,13 +107,18 @@ so it lands in its own singleton bucket in Step 4.
 
 Apply the rules from `triage-guide.md`:
 
-- Two issues share a bucket if their predicted-glob sets share **≥ 1 glob**
-  (Jaccard numerator ≥ 1).
+- **Type separation is absolute.** Features and bugs are bucketed
+  independently. A feature and a bug never share a bucket, even if they
+  touch the same files. The plan template, risk rubric, label state machine,
+  branch prefix, and commit type all diverge by type.
+- **Within a type:** two issues share a bucket if their predicted-glob sets
+  share **≥ 1 glob** (Jaccard numerator ≥ 1).
 - Bucket size is capped at **4 issues**. If a bucket would exceed 4, split it
   using secondary keyword affinity (see the guide).
 - Issues with the `__no-overlap__:<N>` synthetic glob become singleton buckets.
 
-Assign bucket IDs sequentially: `b1`, `b2`, …
+Assign bucket IDs sequentially: `b1`, `b2`, … Bucket IDs are shared across
+types — the bucket entry's `type` field distinguishes them.
 
 For each bucket, write a short **rationale** naming the shared concern
 (e.g. "color tokens", "feature-creator orchestrator", "auth middleware").
@@ -100,18 +134,29 @@ as fallback). Use this exact structure:
   "buckets": [
     {
       "id": "b1",
+      "type": "feature",
       "issues": [
         { "number": 14, "title": "..." },
         { "number": 16, "title": "..." }
       ],
       "predicted_globs": ["plugins/feature-creator/**"],
       "rationale": "feature-creator orchestrator"
+    },
+    {
+      "id": "b2",
+      "type": "bug",
+      "issues": [
+        { "number": 21, "title": "[bug] missing await in inactivity sweep" }
+      ],
+      "predicted_globs": ["apps/api/src/**"],
+      "rationale": "inactivity sweep async ordering"
     }
   ]
 }
 ```
 
-Required top-level keys: `shared_context` (string), `buckets` (array). The
+Required top-level keys: `shared_context` (string), `buckets` (array). Each
+bucket entry must include the `type` field (`"feature"` or `"bug"`). The
 orchestrator validates these after you complete.
 
 Write via a heredoc into the passed path. Example:
@@ -139,6 +184,7 @@ cat > /tmp/triage-<NUMBER>.md << 'TRIAGE_EOF'
 <!-- claude-feature-triager-v1 -->
 ## Triage Summary for #<NUMBER>
 
+**Type:** <feature|bug>
 **Bucket:** `<BUCKET_ID>` — <RATIONALE>
 
 **Bucket-mates:** #<M>, #<K>   (or "none — singleton bucket")
@@ -155,8 +201,23 @@ gh issue comment <NUMBER> --repo <OWNER/REPO> --body-file /tmp/triage-<NUMBER>.m
 
 The comment MUST begin with `<!-- claude-feature-triager-v1 -->`.
 
-Do **not** change issue labels — the planner moves issues from
-`feature - ready for claude` to `feature - planned` once the plan is posted.
+## Step 7: Update Bug Labels
+
+Bug issues are filed with `bug - ready for claude` and have no plan yet. The
+triager moves them to `bug - triaged` so the planner can distinguish "fresh
+from sweeper" from "ready to plan":
+
+```
+# For each bug issue in the manifest:
+gh issue edit <NUMBER> --repo <OWNER/REPO> \
+  --remove-label "bug - ready for claude" \
+  --add-label "bug - triaged"
+```
+
+Do **not** modify feature labels here — the feature-planner moves features
+from `feature - ready for claude` to `feature - planned` after planning.
+Features go through one fewer state because there is no upstream
+discovery agent.
 
 ## Error Handling
 
@@ -172,9 +233,11 @@ The pipeline continues.
 
 When finished, print:
 
-| Bucket | Issues | Rationale |
-|--------|--------|-----------|
-| b1     | #14, #16 | feature-creator orchestrator |
-| b2     | #15 | implementer reliability (singleton) |
+| Bucket | Type | Issues | Rationale |
+|--------|------|--------|-----------|
+| b1 | feature | #14, #16 | feature-creator orchestrator |
+| b2 | bug | #21 | inactivity sweep async ordering (singleton) |
+| b3 | feature | #15 | implementer reliability (singleton) |
 
-Also report the manifest path that was written.
+Also report the manifest path that was written and a per-type count
+("features: X, bugs: Y").

--- a/plugins/feature-creator/commands/feature-creator.md
+++ b/plugins/feature-creator/commands/feature-creator.md
@@ -1,22 +1,50 @@
 ---
 name: feature-creator
-description: End-to-end feature pipeline — plans, reviews, and implements GitHub issues labeled "feature - ready for claude"
+description: End-to-end pipeline — plans, reviews, and implements GitHub issues labeled `feature - ready for claude` or `bug - ready for claude`
 argument-hint: "[repo-owner/repo-name] [--auto-merge]"
 disable-model-invocation: true
 ---
 
 # Feature Creator
 
-You are a feature pipeline orchestrator. You chain agents across six phases (0–5) to
-take GitHub issues from labeled requests through to merged pull requests.
+You are a feature/bug pipeline orchestrator. You chain agents across six phases
+(0–5) to take GitHub issues from labeled requests through to merged pull
+requests. Two parallel state machines run side by side: one for features
+(`feature - *` labels) and one for bug fixes (`bug - *` labels). The triager
+buckets them separately; downstream agents apply the correct template, risk
+rubric, branch prefix, and commit type per type.
 
 **Pipeline**:
-0. **feature-triager** — Shared codebase exploration, group issues into planning buckets
+0. **feature-triager** — Shared codebase exploration, group issues into planning buckets (features and bugs in separate buckets)
 1. **feature-planner** (parallel, one per bucket) — Plan each bucket's issues together
 2. **feature-consolidator** — Holistic consistency review, consolidated plan
-3. **feature-reviewer** — Assess risk, flag dangerous features, final implementation order
+3. **feature-reviewer** — Assess risk, flag dangerous features/bugs, final implementation order
 4. **feature-implementer** — Create branches, write code, run tests, open PRs
-5. **Merge and cleanup** — Merge feature PRs in order, merge release branch, clean up
+5. **Merge and cleanup** — Merge PRs in order, merge release branch, clean up
+
+## Issue types and labels
+
+| Type | Trigger label | Source |
+|------|---------------|--------|
+| Feature | `feature - ready for claude` | Filed by humans |
+| Bug | `bug - ready for claude` | Filed by `bug-sweeper` (or humans) |
+
+State machines:
+
+```
+feature: ready for claude → planned → in progress → complete
+                              ↓ (high risk)
+                          human review
+
+bug:     ready for claude → triaged → planned → in progress → complete
+                                         ↓ (high risk)
+                                     human review
+```
+
+The bug flow has one extra hop (`triaged`) because bug-sweeper writes the
+issue with `bug - ready for claude` and no plan; the triager moves it to
+`bug - triaged` after the bucket pass; the planner moves it to `bug - planned`
+after the plan is posted.
 
 ## Prerequisites
 
@@ -36,10 +64,17 @@ take GitHub issues from labeled requests through to merged pull requests.
    ```
    gh label list --repo <OWNER/REPO> --json name -q '.[].name'
    ```
-   Check for: `feature - ready for claude`, `feature - planned`,
-   `feature - human review`, `feature - in progress`, `feature - complete`.
-   If any are missing, print the `gh label create` commands from the plugin README
-   and stop.
+   Check for the **feature** state machine:
+   - `feature - ready for claude`, `feature - planned`,
+     `feature - human review`, `feature - in progress`, `feature - complete`
+
+   And the **bug** state machine:
+   - `bug`, `bug - ready for claude`, `bug - triaged`, `bug - planned`,
+     `bug - human review`, `bug - in progress`, `bug - complete`,
+     `bug - high`, `bug - medium`, `bug - low`
+
+   If any are missing, print the `gh label create` commands from the plugin
+   README and stop.
 
 ## Phase 0: Triage
 
@@ -66,20 +101,21 @@ Use the Agent tool to launch the **feature-triager** agent with this prompt:
 > You are the feature-triager. Target repository: <OWNER/REPO>
 > Bucket manifest path: <BUCKET_MANIFEST_PATH>
 >
-> Fetch all open issues labeled `feature - ready for claude`, run one shared
-> codebase exploration pass, group the issues into buckets per
-> `references/triage-guide.md`, write the manifest to the path above, and post
+> Fetch all open issues labeled `feature - ready for claude` **or**
+> `bug - ready for claude`, run one shared codebase exploration pass, group
+> the issues into buckets per `references/triage-guide.md` (features and bugs
+> in separate buckets), write the manifest to the path above, and post
 > per-issue triage comments.
 
 Wait for the triager to complete.
 
-If the triager reports "No issues labeled 'feature - ready for claude' found.",
-stop the pipeline and report.
+If the triager reports "No issues labeled `feature - ready for claude` or
+`bug - ready for claude` found.", stop the pipeline and report.
 
-If more than 5 issues were fetched, warn:
+If more than 5 issues were fetched (across both label sets), warn:
 > Found <N> issues — this is a large batch. The triager has grouped them into
-> <M> buckets. Consider removing the trigger label from lower-priority issues
-> to limit the batch size on future runs.
+> <M> buckets (features: <X>, bugs: <Y>). Consider removing trigger labels
+> from lower-priority issues to limit the batch size on future runs.
 
 ### 0c. Validate the bucket manifest (Suggestion 1 — validation gate)
 
@@ -112,7 +148,16 @@ if missing:
 if not isinstance(data["buckets"], list) or len(data["buckets"]) == 0:
     print("ERROR: bucket manifest has no buckets")
     sys.exit(1)
-print(f"OK: bucket manifest valid — {len(data['buckets'])} bucket(s)")
+for i, b in enumerate(data["buckets"]):
+    if "type" not in b:
+        print(f"ERROR: bucket[{i}] missing required 'type' field")
+        sys.exit(1)
+    if b["type"] not in ("feature", "bug"):
+        print(f"ERROR: bucket[{i}] type must be 'feature' or 'bug', got {b['type']!r}")
+        sys.exit(1)
+n_feat = sum(1 for b in data["buckets"] if b["type"] == "feature")
+n_bug  = sum(1 for b in data["buckets"] if b["type"] == "bug")
+print(f"OK: bucket manifest valid — {len(data['buckets'])} bucket(s) (features: {n_feat}, bugs: {n_bug})")
 PY
 ```
 
@@ -275,17 +320,21 @@ gh pr merge <RELEASE_PR_NUMBER> --repo <OWNER/REPO> --squash
 
 ### 5e. Cleanup
 
-Follow the global cleanup conventions from `~/.claude/CLAUDE.md`:
+Follow the global cleanup conventions from `~/.claude/CLAUDE.md`. Branch
+prefix is `feature/` for feature issues and `fix/` for bug issues — clean up
+both:
 
 ```
 git checkout main && git pull
 
-# Delete remote feature branches (always run — --delete-branch in 5b handles
+# Delete remote branches (always run — --delete-branch in 5b handles
 # GitHub's remote ref but local tracking refs require explicit cleanup)
 git push origin --delete feature/<N>-<slug>   # for each feature branch
+git push origin --delete fix/<N>-<slug>       # for each bug-fix branch
 
-# Delete local feature branches
+# Delete local branches
 git branch -D feature/<N>-<slug>              # for each feature branch
+git branch -D fix/<N>-<slug>                  # for each bug-fix branch
 
 # Delete release branch (local and remote)
 git branch -D release/<YYYY-MM-DD>
@@ -311,18 +360,20 @@ After all phases complete (or if the pipeline stops early), print a final report
 ## Feature Creator Pipeline Summary
 
 ### Issues Processed
-| Issue | Title | Planning | Consolidation | Review | Implementation | PR |
-|-------|-------|----------|---------------|--------|----------------|----|
-| #N | Title | OK/Failed | Included/Flagged | Approved/Flagged | OK/Failed | #PR or — |
+| Issue | Type | Title | Planning | Consolidation | Review | Implementation | PR |
+|-------|------|-------|----------|---------------|--------|----------------|----|
+| #N | feature/bug | Title | OK/Failed | Included/Flagged | Approved/Flagged | OK/Failed | #PR or — |
 
 ### Statistics
-- Planned: X
-- Flagged for human review: X
-- Implemented: X
-- Merged: X
+| | Features | Bugs |
+|-|----------|------|
+| Planned | X | X |
+| Flagged for human review | X | X |
+| Implemented | X | X |
+| Merged | X | X |
 
 ### Release
-<Release PR link and merge status, or "Not created (no features implemented)">
+<Release PR link and merge status, or "Not created (nothing implemented)">
 ```
 
 ## Error Handling

--- a/plugins/feature-creator/commands/feature-creator.md
+++ b/plugins/feature-creator/commands/feature-creator.md
@@ -220,8 +220,8 @@ Use the Agent tool to launch the feature-reviewer agent with the following promp
 > You are the feature-reviewer. Target repository: <OWNER/REPO>
 
 Wait for the agent to complete. Check its output:
-- Note which features were approved and which were flagged for human review.
-- If all features were flagged, stop and report.
+- Note which issues (features and bugs) were approved and which were flagged for human review.
+- If all issues were flagged, stop and report.
 - Record the implementation order from the reviewer's output — you will need it in Phase 5.
 
 ## Phase 4: Implementation
@@ -231,12 +231,15 @@ Use the Agent tool to launch the feature-implementer agent with the following pr
 > You are the feature-implementer. Target repository: <OWNER/REPO>
 
 Wait for the agent to complete. Collect its output:
-- Record each feature PR number and the release branch name.
-- Note any features that failed implementation.
+- Record each PR number alongside its issue type (feature or bug) and the
+  source issue number — both feature and bug-fix PRs count. The implementer's
+  output table includes a `Type` column; use it.
+- Record the release branch name.
+- Note any issues that failed implementation.
 
 ## Phase 5: Merge and Cleanup
 
-Only proceed if at least one feature PR was successfully created.
+Only proceed if at least one PR (feature or bug-fix) was successfully created.
 
 ### 5a. Check auto-merge flag
 
@@ -244,45 +247,52 @@ If `--auto-merge` was passed in `$ARGUMENTS`, proceed automatically through all
 steps without pausing. Otherwise, pause before merging the release branch (5c)
 to give the user a final review opportunity.
 
-### 5b. Merge feature PRs
+### 5b. Merge PRs
 
-For each PR in the Phase 4 output list (which already reflects implementation order):
+For each PR in the Phase 4 output list (which already reflects implementation
+order — both feature and bug-fix PRs):
 
 ```
 gh pr merge <PR_NUMBER> --repo <OWNER/REPO> --squash --delete-branch
 ```
 
-If a merge fails, post a comment on the corresponding issue, change its label to
-`feature - human review`, and continue with the next PR.
+If a merge fails, post a comment on the corresponding issue, change its label
+to the **type-appropriate** human-review label, and continue with the next PR:
+
+- Feature issue → `feature - human review`
+- Bug issue → `bug - human review`
 
 ### 5c. Create and merge the release branch PR
 
 The release PR merges `stage` into `main` (the default branch). GitHub only
 auto-closes issues when a PR merges into the default branch, so this is the
-only opportunity in the pipeline to auto-close feature issues — every feature
-issue successfully merged in Phase 5b must appear as a `Closes #<N>` line in
-this PR body. Do **not** emit any explicit `gh issue close` calls; rely on
-GitHub's closing keywords.
+only opportunity in the pipeline to auto-close issues — every feature **or
+bug** issue successfully merged in Phase 5b must appear as a `Closes #<N>`
+line in this PR body. Do **not** emit any explicit `gh issue close` calls;
+rely on GitHub's closing keywords.
 
 Construct the release PR body using the template in
 `references/release-pr-template.md` (read that file for the exact format).
 Populate it from the Phase 4 output:
 
-- The **Summary** section lists one line per successfully-merged feature PR,
-  including PR number, title, and issue number.
-- The **Closes** section has one `Closes #<ISSUE_NUMBER>` line per feature
-  issue that was successfully merged in Phase 5b.
+- The **Summary** section lists one line per successfully-merged PR,
+  including PR number, type marker (`feat` or `fix`), title, and issue
+  number. Group features and bug fixes into separate sub-sections so a
+  human reader can scan them at a glance.
+- The **Closes** section has one `Closes #<ISSUE_NUMBER>` line per merged
+  issue, **regardless of type**. The pre-flight check below depends on
+  every merged issue being represented.
 
-Only include features that were successfully merged. Features that failed to
-merge or were labeled `feature - human review` must NOT appear in the Closes
-section — those issues remain open for manual follow-up.
+Only include PRs that were successfully merged. PRs that failed to merge or
+were labeled `feature - human review` / `bug - human review` must NOT appear
+in the Closes section — those issues remain open for manual follow-up.
 
-**Pre-flight check (required before `gh pr create`).** Build the set of issue
-numbers for every PR merged successfully in Phase 5b. For each issue number,
-confirm the composed body contains a matching `Closes #<N>` line. If any
-merged issue is missing, fail with an error and stop — do not create the PR.
-This guarantees the release merge into `main` will auto-close every feature
-issue landed in this release.
+**Pre-flight check (required before `gh pr create`).** Build the set of
+issue numbers for every PR merged successfully in Phase 5b — across both
+types. For each issue number, confirm the composed body contains a matching
+`Closes #<N>` line. If any merged issue is missing, fail with an error and
+stop — do not create the PR. This guarantees the release merge into `main`
+will auto-close every feature **and bug** issue landed in this release.
 
 Write the body to `/tmp/release-pr-body.md` and create the PR with
 `--body-file`:
@@ -305,7 +315,7 @@ gh pr create --repo <OWNER/REPO> --base main --head release/<YYYY-MM-DD> \
 ```
 
 **If `--auto-merge` was NOT passed**: Stop here. Print the release PR link and ask:
-> All feature PRs have been merged. Release PR: <URL>
+> All PRs have been merged. Release PR: <URL>
 > Respond to confirm and I will merge the release branch and clean up.
 
 Wait for explicit user confirmation before continuing to step 5d.
@@ -378,11 +388,11 @@ After all phases complete (or if the pipeline stops early), print a final report
 
 ## Error Handling
 
-- If an entire phase fails (not individual features within a phase), stop the
+- If an entire phase fails (not individual issues within a phase), stop the
   pipeline and report the error. Do not proceed to the next phase.
-- Individual feature failures within a phase are handled by the agents.
-  The pipeline continues with remaining features.
-- If Phase 1 produces no planned features, stop before Phase 2.
-- If Phase 2 flags all features, stop before Phase 3.
-- If Phase 3 flags all features, stop before Phase 4.
-- If Phase 4 produces no PRs, skip Phase 5.
+- Individual issue failures within a phase are handled by the agents.
+  The pipeline continues with remaining issues.
+- If Phase 1 produces no planned issues (across both types), stop before Phase 2.
+- If Phase 2 flags all issues, stop before Phase 3.
+- If Phase 3 flags all issues, stop before Phase 4.
+- If Phase 4 produces no PRs (across both types), skip Phase 5.

--- a/plugins/feature-creator/references/bug-plan-template.md
+++ b/plugins/feature-creator/references/bug-plan-template.md
@@ -1,0 +1,116 @@
+# Bug-Fix Plan Comment Template
+
+Use this template when posting implementation plans for issues labeled
+`bug - triaged`. The `<!-- claude-bug-planner-v1 -->` marker on the first
+line is required — downstream agents (consolidator, reviewer, implementer)
+use it to locate the plan programmatically.
+
+For feature issues (`feature - planned` flow), use [`plan-template.md`](plan-template.md)
+instead.
+
+---
+
+```markdown
+<!-- claude-bug-planner-v1 -->
+## Bug Fix Plan for #<NUMBER>: <TITLE>
+
+### Summary
+
+<2-3 sentences: what is broken (the user-visible symptom or failure mode),
+the root cause (why the bug exists), and the high-level fix approach.>
+
+### Bucket-mates
+
+<Optional — include only when this issue shares a planning bucket with
+other bugs (bucket size > 1). Omit this section entirely for singleton
+buckets. Bug buckets never contain feature issues.>
+
+- #<M> — <title> — <short note on shared file edits or within-bucket ordering>
+
+<Within-bucket ordering (if relevant): "Land #<X> before #<Y> because …">
+
+### Reproduction Steps
+
+<Concrete steps that demonstrate the bug today. If the bug-sweeper issue
+already provides reproduction steps, restate them here and note any
+additional steps you discovered while reading the code.>
+
+1. ...
+2. ...
+
+Expected: <what should happen>
+Actual: <what does happen>
+
+### Root Cause Analysis
+
+<2-4 sentences: why does the bug exist? What invariant is being violated?
+What assumption was wrong? Cite file:line where the defect lives.>
+
+### Affected Files
+
+| Action | File | Description |
+|--------|------|-------------|
+| Modify | `path/to/buggy.ts` | <what changes — the fix> |
+| Modify | `path/to/buggy.test.ts` | Add a regression test that reproduces the bug |
+
+A bug fix that does not include a regression test in this table will be
+flagged by the reviewer (see `bug-review-checklist.md`).
+
+### Implementation Steps
+
+1. **<Step title>**
+   - <Specific change description>
+   - <Code pattern to follow>
+
+2. **Add regression test**
+   - <Describe the test case>
+   - <Where it goes; why it would have caught the bug>
+
+<Continue as needed.>
+
+### Test Strategy
+
+- **Regression test (REQUIRED)**: <test name and what it verifies>. The
+  test must fail against the unfixed code and pass after the fix.
+- **Existing tests**: <which existing tests cover the surrounding code, and
+  how to verify they still pass>
+- **Manual verification**: <steps to reproduce the bug and confirm the fix
+  resolves it; mirror the Reproduction Steps above>
+
+### Risk Assessment
+
+Assessed against `bug-risk-criteria.md`.
+
+| Factor | Level | Notes |
+|--------|-------|-------|
+| Auth / authz touched | LOW/MEDIUM/HIGH | <explanation> |
+| Concurrency / async | LOW/MEDIUM/HIGH | <explanation> |
+| Hot-path SQL / queries | LOW/MEDIUM/HIGH | <explanation> |
+| Removes code external consumers may rely on | LOW/MEDIUM/HIGH | <explanation> |
+| Error-handling behavior change | LOW/MEDIUM/HIGH | <explanation> |
+| Scope (files touched) | LOW/MEDIUM/HIGH | <count, complexity> |
+
+### Dependencies
+
+- <Other bugs/features this depends on, or "None">
+- <New packages required (rare for bug fixes), or "None">
+```
+
+## Why this template differs from the feature template
+
+A feature plan answers "what new behavior are we adding and how?" A bug-fix
+plan answers "what existing behavior is wrong and how do we restore the
+intended behavior?" The sections that change:
+
+- **Summary** focuses on the broken behavior + root cause + fix, not on a
+  user-facing capability
+- **Reproduction Steps** is required (replaces "user story" / "acceptance
+  criteria" from the feature template)
+- **Root Cause Analysis** is required and cites file:line (no analog in the
+  feature template)
+- **Affected Files** must include a regression test entry — the reviewer
+  enforces this
+- **Test Strategy** has a REQUIRED regression test bullet (a feature plan
+  may have unit + integration only)
+- **Risk Assessment** uses the bug-tuned rubric, not the feature rubric
+- **Dependencies** rarely include new packages (feature plans frequently do)

--- a/plugins/feature-creator/references/bug-review-checklist.md
+++ b/plugins/feature-creator/references/bug-review-checklist.md
@@ -1,0 +1,105 @@
+# Review Checklist for Bug-Fix Plans
+
+Used by the review subagent spawned from `feature-reviewer` when the plan
+under review is for a `bug - planned` issue. For feature plans, use
+[`review-checklist.md`](review-checklist.md) instead.
+
+You are reviewing one or more bug-fix plans. Be specific and actionable.
+
+## Check 1: Root Cause is Identified, Not Just the Symptom
+
+- Does the plan's "Root Cause Analysis" cite a file and line number?
+- Does the explanation match the cited code? (Re-read the file at the
+  cited line.)
+- If the plan describes only the symptom and proposes a fix without
+  identifying the root cause, flag it. Symptom-only fixes often re-emerge
+  in different forms.
+
+## Check 2: Regression Test is Included
+
+- Does the "Affected Files" table include a `Modify` or `Create` entry for
+  a test file?
+- Does the "Test Strategy" describe a regression test that:
+  1. Fails against the unfixed code, AND
+  2. Passes after the fix?
+- If the plan does not include a regression test, flag it as **HIGH**
+  severity. A bug fix without a regression test is a re-emergence waiting
+  to happen.
+
+Exceptions:
+- A pure documentation fix does not need a regression test.
+- A dependency version bump (CVE patch) may rely on the upstream's tests
+  rather than introducing a new one — the plan must say so explicitly.
+
+## Check 3: Dependency Order
+
+- Does the implementation order respect dependencies between bugs in the
+  same bucket?
+- If bug B's fix depends on bug A's fix, is A scheduled first?
+
+## Check 4: File Conflicts
+
+- Do any two bug fixes in the bucket modify the same file?
+- If so, is the ordering correct? The bug whose fix is more structural
+  (e.g., refactors a function) should land before the one making a small
+  change to that function.
+
+## Check 5: Convention Compliance
+
+- Do file modifications follow the project's naming and style conventions?
+- Does the regression test follow the project's existing test patterns
+  (test framework, fixture conventions, mocking rules)?
+- If the plan introduces a new test file, does it sit in the right
+  directory?
+
+## Check 6: Scope Reasonableness
+
+- Is each bug-fix plan achievable in a single implementation pass?
+- If a bug fix touches 5+ files, has the plan articulated why? A wide-scope
+  fix may indicate a misdiagnosed root cause — flag it for human review.
+- Does the plan stay focused on the bug, or does it bundle in unrelated
+  cleanup? Bundled cleanup is a feature-creator anti-pattern — flag it.
+
+## Check 7: Behavioral Compatibility
+
+- Does the fix change behavior in any way that downstream consumers may
+  rely on (even if the prior behavior was buggy)?
+- If the plan removes a function, public method, or API endpoint, does it
+  document why this is safe and what migration callers need (if any)?
+
+## Check 8: Missing Considerations
+
+- Does the plan account for **why** the bug existed in the first place?
+  (e.g., "this code was added before TypeScript strict mode was enabled,
+  so the null case was never type-checked")
+- Are there other places in the codebase that follow the same buggy
+  pattern? If so, does the plan address them or call them out as out of
+  scope?
+- Does the plan update any relevant documentation (READMEs, CLAUDE.md,
+  inline comments) to prevent future regressions?
+
+## Output Format
+
+Return your review as a structured list:
+
+### Issues Found
+
+1. **[Severity: HIGH/MEDIUM/LOW]** <description of the issue and which bug
+   it affects>
+   - **Suggestion**: <how to fix it>
+
+### Approved
+
+If no HIGH issues are found, state: "Plan is approved with the above notes."
+If HIGH issues are found, state: "Plan needs revision before implementation."
+
+## Bug-vs-feature differences in this checklist
+
+- **Test Coverage** check is renamed **Regression Test is Included** and
+  raised in priority — a missing regression test is HIGH severity.
+- **Missing Considerations** explicitly asks "why did the bug exist?" so
+  the plan addresses the original cause, not just the symptom.
+- **Behavioral Compatibility** is new — bug fixes can break downstream
+  consumers who adapted to the bug.
+- The original "Test Coverage" check from the feature checklist is folded
+  into Check 2.

--- a/plugins/feature-creator/references/bug-risk-criteria.md
+++ b/plugins/feature-creator/references/bug-risk-criteria.md
@@ -1,0 +1,71 @@
+# Bug-Fix Risk Assessment Criteria
+
+Use this rubric when reviewing a plan attached to an issue labeled
+`bug - planned`. For feature plans, use [`risk-criteria.md`](risk-criteria.md)
+instead.
+
+A bug fix is **high-risk** if it has any HIGH factor or two or more MEDIUM
+factors. High-risk bugs are flagged for human review (`bug - human review`).
+
+The bug-fix rubric differs from the feature rubric: where features ask "is
+the new code safe?", bug fixes ask "will the change cause a regression or
+break assumptions downstream?" Some factors that raise feature risk lower
+bug-fix risk and vice versa.
+
+## HIGH Risk Factors (bug-specific)
+
+| Factor | Trigger | Why it's HIGH |
+|--------|---------|---------------|
+| Authentication / authorization | Plan touches auth middleware, session management, token handling, or access control | Security blast radius is the same regardless of whether code is added or fixed |
+| Concurrency / async logic | Plan modifies await ordering, Promise composition, queue/worker logic, or retry behavior | Concurrency bugs often have asymmetric blast radius: the fix can introduce a new race that takes weeks to surface |
+| Hot-path SQL or query logic | Plan changes a query that runs on every request, in a sweep, or in a webhook handler | Hot-path query changes can cascade into latency or load issues |
+| Removes code external consumers may rely on | Plan removes a function, API endpoint, or behavior that downstream code may have come to depend on (even if buggy) | Downstream code sometimes "depends on" the broken behavior; removing it is a breaking change |
+| Schema / migration touched | Plan includes DDL, migration files, or schema changes | Same reasoning as feature rubric — irreversible if wrong |
+| Data deletion or destructive change | Plan permanently deletes user data or backfills with deletion | Irreversible data loss if logic is wrong |
+| Error handling that swallows previously-surfaced errors | Plan changes a catch / handler so errors that used to be propagated now return a default | Masks future bugs; harder to detect in production |
+| Secrets / credentials | Plan modifies how API keys, tokens, or secrets are read or stored | Same reasoning as feature rubric |
+
+## MEDIUM Risk Factors (bug-specific)
+
+| Factor | Trigger | Why it's MEDIUM |
+|--------|---------|-----------------|
+| Cache invalidation | Plan changes when caches are populated, evicted, or read | Cache bugs are quiet failures; correctness regressions are easy to miss |
+| Retry / timeout / backoff | Plan modifies retry logic, timeouts, or backoff parameters | Wrong values cascade into thundering-herd or stuck-flow problems |
+| Data backfill | Plan includes a data backfill or one-time migration step | Backfills are easy to misorder; verifying completeness is hard |
+| Cross-cutting scope | Plan touches 5+ files or spans 2+ distinct modules to fix one bug | Suggests the root cause may be wider than diagnosed; verify by re-reading the bug-sweeper issue |
+| External API integration changed | Plan modifies how a third-party API is called | Behavior change at a trust boundary |
+| Performance-sensitive path | Plan modifies hot paths, indexed query construction, or memoization | Performance regressions may not be caught by tests |
+| New dependency / version bump | Plan bumps a dependency to fix a CVE or get a patched API | Version bumps drag in unrelated changes; risk depends on the dep |
+
+## LOW Risk Factors (bug-specific)
+
+| Factor | Trigger | Why it's LOW |
+|--------|---------|--------------|
+| UI-only fix | Plan only touches templates, styles, or copy | Visual changes are easy to verify and revert |
+| Documentation / comment fix | Plan only modifies docs, comments, or error messages | No runtime impact |
+| Adds missing validation | Plan adds an input check that previously was not present | Lowers risk rather than raising it; no existing valid input is rejected |
+| Adds missing await / null-check on a non-critical path | Plan inserts a single guard or `await` in a request handler with existing error handling | Defensive edit; tightens correctness without changing happy-path behavior |
+| Modifies a private internal function | Plan changes a non-exported helper used in 1-2 places | Bounded blast radius |
+| Test-only change | Plan only adds or updates regression tests | Improves coverage without affecting production code |
+
+## How to apply
+
+1. Read the bug fix plan's "Reproduction Steps", "Root Cause Analysis",
+   "Affected Files", and "Implementation Steps".
+2. Check each risk factor above against the plan.
+3. Record which factors apply and at what level.
+4. Determine overall risk:
+   - **Any HIGH factor** → high-risk → flag for human review (`bug - human review`)
+   - **2+ MEDIUM factors** → high-risk → flag for human review
+   - **1 MEDIUM factor** → acceptable risk → proceed
+   - **All LOW** → low risk → proceed
+5. When flagging, cite the specific factors and explain why they apply.
+
+## Why some factors flip vs. the feature rubric
+
+| Factor | Feature rubric | Bug rubric | Why |
+|--------|----------------|------------|-----|
+| "Adds new validation" | MEDIUM (new behavior, potential edge cases) | LOW (no existing valid input is rejected) | Direction: bugs *add* a missing check; features add a new gate |
+| "Modifies a private internal function" | MEDIUM (callers may break) | LOW (callers are inside the same module — easy to verify) | Bug fixes target known callers; features may have broader call sites |
+| "Removes deprecated code" | LOW–MEDIUM (deprecation expected the removal) | HIGH (the removal *is* the bug fix; downstream may have come to rely on the broken behavior) | Removing buggy code can break callers that adapted to the bug |
+| "Cross-cutting scope" | MEDIUM at 10+ files | MEDIUM at 5+ files | A bug fix that touches many files often signals a misdiagnosed root cause |

--- a/plugins/feature-creator/references/merge-checklist.md
+++ b/plugins/feature-creator/references/merge-checklist.md
@@ -22,7 +22,31 @@ git commit -m "<type>: <description>
 Closes #<ISSUE_NUMBER>"
 ```
 
-Use conventional commit types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`.
+Conventional commit type **must match the issue type**:
+
+| Issue type | Commit type |
+|------------|-------------|
+| Feature (`feature - planned`) | `feat:` |
+| Bug (`bug - planned`) | `fix:` |
+
+Other conventional types (`refactor`, `test`, `docs`, `chore`) may be used
+if the change genuinely matches one of those — but the issue type takes
+precedence over secondary cleanup. A bug fix that also adds a test is still
+`fix:`, not `test:`.
+
+Example for a feature:
+```
+git commit -m "feat: add dark mode toggle to settings
+
+Closes #42"
+```
+
+Example for a bug:
+```
+git commit -m "fix: await db.write before removing session in inactivity sweep
+
+Closes #21"
+```
 
 ## 3. Post-conflict diff verification
 
@@ -37,9 +61,10 @@ git diff origin/stage -- <planned-file>
 ```
 
 Every planned `Create`/`Modify` file must show a non-empty diff. If any planned
-file shows no diff, conflict resolution silently dropped the feature — do not
-push. Abort and escalate: label the issue `feature - human review` with a
-comment identifying the file that lost its changes.
+file shows no diff, conflict resolution silently dropped the change — do not
+push. Abort and escalate: label the issue per type (`feature - human review`
+or `bug - human review`) with a comment identifying the file that lost its
+changes.
 
 ## 4. Push
 

--- a/plugins/feature-creator/references/pr-template.md
+++ b/plugins/feature-creator/references/pr-template.md
@@ -1,6 +1,8 @@
 # PR Template
 
-Use this template when creating pull requests for implemented features.
+Use this template when creating pull requests for implemented features and
+bug fixes. The `## Root Cause` section is required for bug fixes and omitted
+for features.
 
 ---
 
@@ -9,6 +11,13 @@ Use this template when creating pull requests for implemented features.
 
 <2-3 sentences describing what this PR does and why, taken from the
 implementation plan.>
+
+## Root Cause
+
+<Bug fixes only — omit this section for features. 2-3 sentences explaining
+why the bug existed: what invariant was violated, what assumption was wrong,
+or what code path was overlooked. This belongs in the PR body so reviewers
+and future archaeologists can understand the fix without opening the issue.>
 
 ## Changes
 
@@ -19,6 +28,7 @@ implementation plan.>
 ## Testing
 
 - <Tests added or updated>
+- <For bug fixes: name of the regression test and what it verifies>
 - <Build verification result>
 - <Manual verification steps, if any>
 
@@ -29,3 +39,13 @@ Closes #<ISSUE_NUMBER>
 ---
 *Automated by feature-implementer*
 ```
+
+## Title format
+
+| Issue type | PR title prefix |
+|------------|-----------------|
+| Feature | `feat: <description>` |
+| Bug | `fix: <description>` |
+
+The conventional-commit prefix in the title matches the commit type used for
+the squash-merge. See `merge-checklist.md` for the per-type guidance.

--- a/plugins/feature-creator/references/release-pr-template.md
+++ b/plugins/feature-creator/references/release-pr-template.md
@@ -5,15 +5,17 @@ Use this template to construct the release PR body. The orchestrator
 Phase 4 implementation output.
 
 The **`Closes` section is required**. GitHub only auto-closes issues when a PR
-merges into the repository's default branch (`main`). Feature PRs merge into
-`stage`, so feature-level auto-close does not fire. The release PR is the only
-merge into `main`, so every feature issue that landed in this release must
-appear as a `Closes #<N>` line in this body — otherwise the issues will remain
-open after the release merges and require manual cleanup.
+merges into the repository's default branch (`main`). Feature and bug-fix PRs
+merge into `stage`, so per-issue auto-close does not fire there. The release
+PR is the only merge into `main`, so every feature **and bug** issue that
+landed in this release must appear as a `Closes #<N>` line in this body —
+otherwise the issues will remain open after the release merges and require
+manual cleanup.
 
 Before calling `gh pr create`, the orchestrator must confirm that every
-successfully-merged feature issue from Phase 4 appears in the `Closes` section.
-Missing entries must fail the pre-flight check and block PR creation.
+successfully-merged issue from Phase 4 (across both types) appears in the
+`Closes` section. Missing entries must fail the pre-flight check and block PR
+creation.
 
 ---
 
@@ -22,26 +24,42 @@ Missing entries must fail the pre-flight check and block PR creation.
 
 ## Summary
 
-This release bundles the following merged feature PRs from `stage`:
+This release bundles the following PRs merged into `stage`:
+
+### Features
 
 - #<PR_NUMBER> — <Feature title> (issue #<ISSUE_NUMBER>)
-- #<PR_NUMBER> — <Feature title> (issue #<ISSUE_NUMBER>)
-<!-- one line per successfully-merged feature PR -->
+<!-- one line per successfully-merged feature PR; omit this section if none -->
+
+### Bug fixes
+
+- #<PR_NUMBER> — <Bug title> (issue #<ISSUE_NUMBER>)
+<!-- one line per successfully-merged bug-fix PR; omit this section if none -->
 
 ## Closes
 
 <!--
-One `Closes #<N>` line per feature issue landed in this release.
-GitHub parses these keywords on merge into the default branch and
-auto-closes the referenced issues. Do NOT remove or rename this
+One `Closes #<N>` line per issue (feature OR bug) that landed in this
+release. GitHub parses these keywords on merge into the default branch
+and auto-closes the referenced issues. Do NOT remove or rename this
 section — the orchestrator's pre-flight check looks for it.
 -->
 
 Closes #<ISSUE_NUMBER>
 Closes #<ISSUE_NUMBER>
-<!-- one line per issue -->
+<!-- one line per issue, regardless of type -->
 
 ---
 
 Automated by feature-creator.
 ```
+
+## Section omission rules
+
+- If the run merged only features, omit the `### Bug fixes` heading and its
+  body.
+- If the run merged only bug fixes, omit the `### Features` heading and its
+  body.
+- The `## Closes` section is always present and lists both types together —
+  GitHub doesn't care about the structure of the body, only that each
+  closing keyword resolves to a real issue.

--- a/plugins/feature-creator/references/triage-guide.md
+++ b/plugins/feature-creator/references/triage-guide.md
@@ -1,7 +1,9 @@
 # Triage Guide
 
 Heuristics and rules for grouping issues into planning buckets. Used by the
-`feature-triager` agent in Phase 0 of the feature-creator pipeline.
+`feature-triager` agent in Phase 0 of the feature-creator pipeline. Applies
+to **both** features (`feature - ready for claude`) and bugs
+(`bug - ready for claude`).
 
 ## Goal
 
@@ -9,6 +11,43 @@ Group issues that are likely to touch the same files into a single bucket so
 that one planner agent can reason about them together. This cuts redundant
 codebase exploration and catches within-bucket file conflicts at plan time
 instead of at implementation time.
+
+## Type-Separation Rule (Absolute)
+
+**Features and bugs are bucketed independently.** A feature and a bug never
+share a bucket, even if their predicted globs overlap. The downstream
+planner, consolidator, reviewer, and implementer apply different templates,
+risk rubrics, plan markers, branch prefixes, and commit types per type —
+mixing types inside a bucket would make those agents misclassify the
+bucket.
+
+The triager:
+1. Fetches `feature - ready for claude` issues and `bug - ready for claude`
+   issues separately
+2. Tags each issue with its `type` (`"feature"` or `"bug"`)
+3. Runs the bucketing rules below **per type**
+4. Emits a single manifest containing buckets of both types, each with a
+   `type` field
+
+If a feature and a bug both touch `apps/api/src/sweep.ts`, they end up in
+two separate buckets even if those buckets are otherwise singletons. This
+is intentional.
+
+## Bug Issue Body Recognition
+
+Bug issues filed by upstream discovery agents (e.g. `bug-sweeper`) begin
+with the marker `<!-- claude-bug-sweeper-v1 -->` and contain explicit
+`**File:**` and `**Lines:**` fields in their body. When such a body is
+present, the triager **must** prefer those explicit citations over
+keyword heuristics when computing predicted globs.
+
+Bugs filed by humans may not include explicit file:line citations. Fall
+back to keyword heuristics in that case.
+
+(This rule does not link to upstream-plugin documentation: the marker
+string and field names above are the only details the triager needs at
+runtime, so feature-creator stays installable without any specific
+upstream filer present.)
 
 ## Predicting Impacted Globs
 
@@ -43,19 +82,37 @@ signals, in order of confidence:
 | `feature-creator`, `planner`, `consolidator`, `reviewer`, `implementer`, `triager` | `plugins/feature-creator/**` |
 | `security-scanner`, `security-runner`, `security-triager`, `security-closer`, `security-advisor`, `supabase` | `plugins/security-scanner/**` |
 | `marketplace`, `plugin.json`, `plugin manifest` | `.claude-plugin/**`, `plugins/*/.claude-plugin/**` |
+| `bug-sweeper`, `bug-sweeper-runner`, `bug-sweeper-reviewer`, `bug-sweeper-tracer`, `bug-sweeper-reconciler`, `bug-sweeper-analyst`, `bug-sweeper-filer` | `plugins/bug-sweeper/**` |
+
+Bug-specific keywords (apply when an issue's `type` is `bug` and the body
+does not contain explicit file paths):
+
+| Keyword(s) in issue | Glob |
+|---------------------|------|
+| `crash`, `regression`, `broken`, `fails`, `error`, `exception` | use the file path in the body's `**File:**` line if present, otherwise apply the table above |
+| `await`, `async`, `promise`, `race condition` | `apps/api/src/**`, `**/handlers/**`, `**/sweep*` |
+| `xss`, `injection`, `csrf`, `sanitize` | `apps/web/**`, `**/views/**`, `**/templates/**` |
+| `leak`, `memory`, `cleanup`, `timeout`, `interval` | `**/sweep*`, `**/cleanup*`, `**/cron*` |
+| `cve`, `vulnerability`, `npm audit` | `package.json`, `package-lock.json` |
 
 Extend the table when recurring signals emerge. If nothing matches, the issue
 falls to a singleton bucket (see below).
 
-## Grouping Rule (Jaccard ≥ 1)
+## Grouping Rule (Jaccard ≥ 1, within type)
 
-Two issues share a bucket if their predicted-glob sets share **at least one
-glob** — equivalently, `|A ∩ B| ≥ 1`. Glob comparison is a literal-string match
-on normalized glob text; do not attempt to expand wildcards for comparison.
+Two issues share a bucket if and only if **both** of these hold:
 
-Bucketing is transitive: if A shares a glob with B, and B shares a different
-glob with C, all three go in the same bucket. Start with each issue in its
-own set and union any two sets that share a glob; repeat until stable.
+1. They are the same `type` (both features or both bugs).
+2. Their predicted-glob sets share **at least one glob** — equivalently,
+   `|A ∩ B| ≥ 1`. Glob comparison is a literal-string match on normalized
+   glob text; do not attempt to expand wildcards for comparison.
+
+Bucketing is transitive **within a type**: if feature A shares a glob with
+feature B, and feature B shares a different glob with feature C, all three
+go in the same bucket. Start with each issue in its own set and union any
+two sets that satisfy both rules above; repeat until stable.
+
+Cross-type unioning is never performed.
 
 ## Maximum Bucket Size
 
@@ -108,16 +165,27 @@ The triager emits this JSON structure (to the path passed by the orchestrator):
   "buckets": [
     {
       "id": "b1",
+      "type": "feature",
       "issues": [
         { "number": 14, "title": "..." }
       ],
       "predicted_globs": ["plugins/feature-creator/**"],
       "rationale": "feature-creator orchestrator"
+    },
+    {
+      "id": "b2",
+      "type": "bug",
+      "issues": [
+        { "number": 21, "title": "[bug] missing await in inactivity sweep" }
+      ],
+      "predicted_globs": ["apps/api/src/**", "**/sweep*"],
+      "rationale": "inactivity sweep async ordering"
     }
   ]
 }
 ```
 
-Top-level required keys: `shared_context` (string) and `buckets` (array). The
-orchestrator validates these immediately after the triager completes. A
-malformed manifest halts the pipeline.
+Top-level required keys: `shared_context` (string) and `buckets` (array).
+Each bucket entry must include the `type` field (`"feature"` or `"bug"`).
+The orchestrator validates these immediately after the triager completes.
+A malformed manifest halts the pipeline.


### PR DESCRIPTION
## Summary

- **bug-sweeper v0.1.0** (new): daily bug-discovery sweep for Node.js / TypeScript repos. Runs `npm run build` + `npm audit` + multi-agent code review, filters false positives, and files each confirmed bug as a GitHub Issue labeled \`bug - ready for claude\`. Supports \`--headless\` mode for scheduled routines. **Find-only** — never proposes fixes.
- **feature-creator v0.5.0 → v0.6.0**: adds a parallel bug state machine alongside features (\`bug - ready for claude → triaged → planned → in progress → complete\`). Triager keeps feature and bug buckets separate. Downstream agents apply type-tuned plan template, risk rubric, review checklist, branch prefix (\`fix/\`), and commit type (\`fix:\`).
- **Marketplace + root docs** updated to register the new plugin and document the dual-pipeline.

The split decouples bug discovery from remediation so each pipeline has its own failure modes, cadences, and rigor profile. bug-sweeper writes issues; feature-creator reads them.

## Architecture

| Concern | Feature path | Bug path |
|---------|--------------|----------|
| Trigger label | \`feature - ready for claude\` | \`bug - ready for claude\` |
| Plan template | [plan-template.md](plugins/feature-creator/references/plan-template.md) | [bug-plan-template.md](plugins/feature-creator/references/bug-plan-template.md) |
| Risk rubric | [risk-criteria.md](plugins/feature-creator/references/risk-criteria.md) | [bug-risk-criteria.md](plugins/feature-creator/references/bug-risk-criteria.md) |
| Review checklist | [review-checklist.md](plugins/feature-creator/references/review-checklist.md) | [bug-review-checklist.md](plugins/feature-creator/references/bug-review-checklist.md) |
| Branch | \`feature/<N>-<slug>\` | \`fix/<N>-<slug>\` |
| Commit | \`feat:\` | \`fix:\` |

## Notable design decisions

- **Type separation in triager is absolute.** Features and bugs never share a bucket, even if their predicted globs overlap — the downstream rubrics diverge enough that mixing types causes downstream agents to misclassify.
- **No fingerprint-based dedup in bug-sweeper v0.1.0** (per user decision). Each run files fresh issues. The reconciler cross-checks against currently-open \`bug\` issues to avoid intra-run duplicates. The \`<!-- claude-bug-sweeper-v1 -->\` marker is reserved on every issue body so a future closer/triager can be added without breaking historical issues.
- **Two execution modes**: interactive (default) enters plan mode at Phase 5 and waits for approval; \`--headless\` skips the gate entirely (analyst's Phase 5 self-review replaces human approval). Designed for invocation from a \`/schedule\` routine in permissions-bypass mode.
- **Bug-tuned risk rubric** has factors that flip vs. the feature rubric (e.g., \"removes deprecated code\" is HIGH for bugs because downstream may have come to rely on the broken behavior, but LOW–MEDIUM for features).

## Test plan

- [ ] \`/plugin marketplace add /path/to/this/repo\` exposes both \`/bug-sweeper\` and \`/feature-creator\` slash commands
- [ ] \`gh label create\` commands from the bug-sweeper README produce all 11 required labels (5 feature + 11 bug labels — see [feature-creator README](plugins/feature-creator/README.md#quick-start))
- [ ] On a sandbox repo with one planted bug (e.g. missing \`await\`):
  - [ ] \`/bug-sweeper sandbox-repo --headless\` files an issue with \`bug\`, \`bug - ready for claude\`, and a severity label; body includes \`<!-- claude-bug-sweeper-v1 -->\` marker, file:line, root cause, repro
  - [ ] \`/feature-creator sandbox-repo\` moves the issue through \`bug - triaged → bug - planned → bug - in progress → bug - complete\`
  - [ ] PR branch is \`fix/<N>-<slug>\` and commit type is \`fix:\`
- [ ] Interactive run (no \`--headless\`) presents plan and waits for approval before any \`gh issue create\` runs
- [ ] Mixed pipeline run (one feature + one bug touching the same file) produces two separate buckets in the triager manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)