### PR TITLE
fix(bug-sweeper): sync plugin.json description with marketplace.json

### DIFF
--- a/plugins/bug-sweeper/.claude-plugin/plugin.json
+++ b/plugins/bug-sweeper/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bug-sweeper",
-  "description": "Daily bug-discovery sweep — runs build/audit + multi-agent code review, filters false positives, files confirmed bugs as GitHub Issues for feature-creator to remediate.",
+  "description": "Daily bug-discovery sweep for Node.js apps — runs build/audit + multi-agent code review, filters false positives, and files confirmed bugs as GitHub Issues for feature-creator to remediate.",
   "version": "0.1.0",
   "author": {
     "name": "schmimran"


### PR DESCRIPTION
## Summary
- bug-sweeper was the only plugin whose `plugin.json` description diverged from its `marketplace.json` entry. The other three plugins keep both copies identical — this aligns to that convention.

## Test plan
- [x] `python3` parity check confirms plugin.json and marketplace.json descriptions are now byte-identical.
- [ ] Re-test `/bug-sweeper` in Claude Desktop on macOS after merge to confirm whether the loader symptom is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)