### PR TITLE
feat: Cowork-native voice-forge UX with reliable path resolution (#35, #33, #34)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,7 +44,7 @@
       "name": "voice-forge",
       "source": "./plugins/voice-forge",
       "description": "Analyze a sent-mail export to produce a data-driven written voice profile, then optionally generate a personalized ghostwriting skill.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "schmimran"
       }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Plugins are self-contained: each lives in its own directory with its own agents,
 | [security-scanner](plugins/security-scanner/) | 0.4.0 | Multi-tool security audit for Node.js web apps and Supabase projects — files findings as GitHub Issues with deduplication, reopen on re-detection, and expert advisory comments | [README](plugins/security-scanner/README.md) |
 | [docs-steward](plugins/docs-steward/) | 0.5.0 | Docs maintenance pipeline — builds canonical indexes of a repo, audits docs for drift, duplication, orphans, and onboarding gaps, then actively edits docs and opens a PR | [README](plugins/docs-steward/README.md) |
 | [bug-sweeper](plugins/bug-sweeper/) | 0.1.1 | Daily bug-discovery sweep for Node.js apps — runs build/audit + multi-agent code review, filters false positives, and files confirmed bugs as GitHub Issues for feature-creator to remediate | [README](plugins/bug-sweeper/README.md) |
-| [voice-forge](plugins/voice-forge/) | 0.1.0 | Analyze a sent-mail export to produce a data-driven written voice profile, then optionally generate a personalized ghostwriting skill | [README](plugins/voice-forge/README.md) |
+| [voice-forge](plugins/voice-forge/) | 0.2.0 | Analyze a sent-mail export to produce a data-driven written voice profile, then optionally generate a personalized ghostwriting skill | [README](plugins/voice-forge/README.md) |
 
 ## What Each Plugin Does
 

--- a/plugins/voice-forge/.claude-plugin/plugin.json
+++ b/plugins/voice-forge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-forge",
   "description": "Analyze a sent-mail export to produce a data-driven written voice profile, then optionally generate a personalized ghostwriting skill",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "schmimran"
   }

--- a/plugins/voice-forge/README.md
+++ b/plugins/voice-forge/README.md
@@ -21,19 +21,33 @@ Turns the findings doc into a `voice-skill/` directory containing a `SKILL.md` t
 ## Commands
 
 ```
-/analyze-writing-voice [--work-dir /path/to/output]
+/analyze-writing-voice
 /build-ghostwriting-skill --findings /path/voice-findings.md
 ```
+
+`/analyze-writing-voice` takes no arguments. It scans the folder you attach to
+the session, detects your sender addresses, and confirms once before running.
+Outputs land in a `voice-forge-work/` folder inside your attached exports folder.
+
+## Execution requirement (Cowork / Claude Desktop only)
+
+`/analyze-writing-voice` runs **only in a Cowork or Claude Desktop session**. It
+resolves its bundled scripts from the mounted plugin directory and reads your
+exports from an attached folder under `/sessions`. In a plain terminal session
+neither is available, so the command fast-fails with a clear message instead of
+guessing. (See Rule 7 in [`references/lessons-learned.md`](references/lessons-learned.md).)
 
 ## Quick start
 
 1. Export your sent mail ([per-client instructions](references/export-guide.md)), create a folder, and drop all archive files into it.
-2. Run `/analyze-writing-voice` — it will ask for the folder path and your email address(es).
-4. Review the findings doc it produces.
+2. Attach that folder to a Cowork or Claude Desktop session.
+3. Run `/analyze-writing-voice` — it scans the attached folder, detects your sender address(es), and asks you to confirm once before parsing.
+4. Review the findings doc it produces (saved to `voice-forge-work/voice-findings.md` inside your exports folder).
 5. Optionally run `/build-ghostwriting-skill` to generate the ghostwriting skill.
 
 ## Prerequisites
 
+- **A Cowork or Claude Desktop session** with your exports folder attached
 - **Python 3** (standard library only — no pip dependencies)
 - A local mail export (`.mbox`, `.olm`, or `.mbox` bundle from Apple Mail)
 
@@ -49,7 +63,7 @@ Mixed-client setups work: drop an `.olm` and one or more `.mbox` files into the 
 
 ## Privacy
 
-All parsing and analysis runs locally. The archive files are read by Python scripts in the `scripts/` directory. No data is sent to any server. The output files (JSON dataset, findings doc, skill) stay in the working directory you specify.
+All parsing and analysis runs locally. The archive files are read by Python scripts in the `scripts/` directory. No data is sent to any server. The output files (JSON dataset, findings doc, skill) stay in a `voice-forge-work/` folder inside the exports folder you attach.
 
 ## Labels
 

--- a/plugins/voice-forge/agents/voice-analyst.md
+++ b/plugins/voice-forge/agents/voice-analyst.md
@@ -14,7 +14,12 @@ Read `references/lessons-learned.md` before starting. Rules 2, 4, and 5 apply to
 You receive:
 - `DATASET_PATH` — path to `email_dataset.json`
 - `WORK_DIR` — working directory
-- `SCRIPTS_DIR` — absolute path to `plugins/voice-forge/scripts/`
+- `SCRIPTS_DIR` — absolute path to the mounted `voice-forge/scripts/` directory
+- `PLUGIN_REFS_DIR` — absolute path to the mounted `voice-forge/references/` directory
+
+<!-- Use $SCRIPTS_DIR / $PLUGIN_REFS_DIR only in Bash/Read calls. Instruction
+     prose (injected from the mounted plugin dir at invocation) refers to
+     references/... by name. -->
 
 ---
 

--- a/plugins/voice-forge/agents/voice-analyst.md
+++ b/plugins/voice-forge/agents/voice-analyst.md
@@ -17,10 +17,6 @@ You receive:
 - `SCRIPTS_DIR` — absolute path to the mounted `voice-forge/scripts/` directory
 - `PLUGIN_REFS_DIR` — absolute path to the mounted `voice-forge/references/` directory
 
-<!-- Use $SCRIPTS_DIR / $PLUGIN_REFS_DIR only in Bash/Read calls. Instruction
-     prose (injected from the mounted plugin dir at invocation) refers to
-     references/... by name. -->
-
 ---
 
 ## Step 1 — Run analysis

--- a/plugins/voice-forge/agents/voice-example-reader.md
+++ b/plugins/voice-forge/agents/voice-example-reader.md
@@ -14,7 +14,12 @@ Read `references/lessons-learned.md` before starting. **Rule 3 is your primary c
 You receive:
 - `DATASET_PATH` — path to `email_dataset.json`
 - `WORK_DIR` — working directory
-- `SCRIPTS_DIR` — absolute path to `plugins/voice-forge/scripts/`
+- `SCRIPTS_DIR` — absolute path to the mounted `voice-forge/scripts/` directory
+- `PLUGIN_REFS_DIR` — absolute path to the mounted `voice-forge/references/` directory
+
+<!-- Use $SCRIPTS_DIR / $PLUGIN_REFS_DIR only in Bash/Read calls. Instruction
+     prose (injected from the mounted plugin dir at invocation) refers to
+     references/... by name. -->
 
 ---
 

--- a/plugins/voice-forge/agents/voice-example-reader.md
+++ b/plugins/voice-forge/agents/voice-example-reader.md
@@ -17,10 +17,6 @@ You receive:
 - `SCRIPTS_DIR` — absolute path to the mounted `voice-forge/scripts/` directory
 - `PLUGIN_REFS_DIR` — absolute path to the mounted `voice-forge/references/` directory
 
-<!-- Use $SCRIPTS_DIR / $PLUGIN_REFS_DIR only in Bash/Read calls. Instruction
-     prose (injected from the mounted plugin dir at invocation) refers to
-     references/... by name. -->
-
 ---
 
 ## Step 1 — Generate candidate examples

--- a/plugins/voice-forge/agents/voice-findings-writer.md
+++ b/plugins/voice-forge/agents/voice-findings-writer.md
@@ -17,9 +17,6 @@ You receive:
 - `SAVE_PATH` — where to write the findings doc
 - `PLUGIN_REFS_DIR` — absolute path to the mounted `voice-forge/references/` directory
 
-<!-- Use $PLUGIN_REFS_DIR only in Read calls. Instruction prose (injected from
-     the mounted plugin dir at invocation) refers to references/... by name. -->
-
 ---
 
 ## Step 1 — Load all inputs

--- a/plugins/voice-forge/agents/voice-findings-writer.md
+++ b/plugins/voice-forge/agents/voice-findings-writer.md
@@ -15,6 +15,10 @@ Read `references/lessons-learned.md` before writing — the caveats in rules 4 a
 You receive:
 - `WORK_DIR` — working directory containing all intermediate outputs
 - `SAVE_PATH` — where to write the findings doc
+- `PLUGIN_REFS_DIR` — absolute path to the mounted `voice-forge/references/` directory
+
+<!-- Use $PLUGIN_REFS_DIR only in Read calls. Instruction prose (injected from
+     the mounted plugin dir at invocation) refers to references/... by name. -->
 
 ---
 
@@ -26,7 +30,7 @@ Read each of these files before writing:
 - `$WORK_DIR/verified-quotes.json` — verified example excerpts
 - `$WORK_DIR/voice-parser-output.json` — data provenance (sources, row count, date range)
 - `$WORK_DIR/results.txt` — raw stats output (for any numbers not in the analyst JSON)
-- `references/findings-template.md` — structure to follow
+- `$PLUGIN_REFS_DIR/findings-template.md` — structure to follow
 
 If any of these files is missing, STOP and report which file is absent before writing anything.
 

--- a/plugins/voice-forge/agents/voice-parser.md
+++ b/plugins/voice-forge/agents/voice-parser.md
@@ -15,7 +15,13 @@ You receive:
 - `ARCHIVE_DIR` — directory containing one or more archive files
 - `OWNER_EMAILS` — comma-separated list of the user's email addresses
 - `WORK_DIR` — output directory (already created)
-- `SCRIPTS_DIR` — absolute path to `plugins/voice-forge/scripts/`
+- `SCRIPTS_DIR` — absolute path to the mounted `voice-forge/scripts/` directory
+- `PLUGIN_REFS_DIR` — absolute path to the mounted `voice-forge/references/` directory
+
+<!-- Use $SCRIPTS_DIR / $PLUGIN_REFS_DIR only in Bash/Read calls. Instruction
+     prose (injected from the mounted plugin dir at invocation) refers to
+     references/... by name. -->
+Read `$PLUGIN_REFS_DIR/lessons-learned.md` before starting (the prose reference above resolves to this same file).
 
 ---
 

--- a/plugins/voice-forge/agents/voice-parser.md
+++ b/plugins/voice-forge/agents/voice-parser.md
@@ -18,11 +18,6 @@ You receive:
 - `SCRIPTS_DIR` — absolute path to the mounted `voice-forge/scripts/` directory
 - `PLUGIN_REFS_DIR` — absolute path to the mounted `voice-forge/references/` directory
 
-<!-- Use $SCRIPTS_DIR / $PLUGIN_REFS_DIR only in Bash/Read calls. Instruction
-     prose (injected from the mounted plugin dir at invocation) refers to
-     references/... by name. -->
-Read `$PLUGIN_REFS_DIR/lessons-learned.md` before starting (the prose reference above resolves to this same file).
-
 ---
 
 ## Step 1 — Discover archives

--- a/plugins/voice-forge/commands/analyze-writing-voice.md
+++ b/plugins/voice-forge/commands/analyze-writing-voice.md
@@ -22,8 +22,9 @@ Resolve the scripts and references directories from the mounted plugin under
 `/sessions`. Both lookups must succeed before anything else runs:
 
 ```bash
-SCRIPTS_DIR="$(find /sessions -path "*/voice-forge/scripts" -type d 2>/dev/null | head -1)"
-PLUGIN_REFS_DIR="$(find /sessions -path "*/voice-forge/references" -type d 2>/dev/null | head -1)"
+_VF_ROOT="$(find /sessions -type d -name voice-forge 2>/dev/null | head -1)"
+SCRIPTS_DIR="$_VF_ROOT/scripts"
+PLUGIN_REFS_DIR="$_VF_ROOT/references"
 
 if [ -z "$SCRIPTS_DIR" ] || [ ! -f "$SCRIPTS_DIR/parse_mbox.py" ]; then
   echo "ERROR: could not locate voice-forge scripts under /sessions."
@@ -64,16 +65,9 @@ Scan the attached session folder(s) under `/sessions` for recognizable archive
 files and derive the inputs automatically — do not prompt for the path:
 
 ```bash
-ATTACHED_DIR="$(find /sessions -maxdepth 4 -type d \
-  \( -iname '*.mbox' -o -name '*' \) 2>/dev/null \
-  | xargs -I{} sh -c 'ls "{}"/*.olm "{}"/*.mbox 2>/dev/null | head -1 >/dev/null 2>&1 && echo "{}"' \
-  | head -1)"
-
-# Fallback: locate the directory that directly contains any archive file.
-if [ -z "$ATTACHED_DIR" ]; then
-  ATTACHED_DIR="$(find /sessions -type f \( -iname '*.olm' -o -iname '*.mbox' \) 2>/dev/null \
-    | head -1 | xargs -r dirname)"
-fi
+# Locate the directory containing any archive file.
+ATTACHED_DIR="$(find /sessions -type f \( -iname '*.olm' -o -iname '*.mbox' \) 2>/dev/null \
+  | head -1 | xargs -r dirname)"
 # Apple Mail bundles are directories named *.mbox — also detect those.
 if [ -z "$ATTACHED_DIR" ]; then
   ATTACHED_DIR="$(find /sessions -type d -iname '*.mbox' 2>/dev/null \

--- a/plugins/voice-forge/commands/analyze-writing-voice.md
+++ b/plugins/voice-forge/commands/analyze-writing-voice.md
@@ -26,7 +26,7 @@ _VF_ROOT="$(find /sessions -type d -name voice-forge 2>/dev/null | head -1)"
 SCRIPTS_DIR="$_VF_ROOT/scripts"
 PLUGIN_REFS_DIR="$_VF_ROOT/references"
 
-if [ -z "$SCRIPTS_DIR" ] || [ ! -f "$SCRIPTS_DIR/parse_mbox.py" ]; then
+if [ -z "$_VF_ROOT" ] || [ ! -f "$SCRIPTS_DIR/parse_mbox.py" ]; then
   echo "ERROR: could not locate voice-forge scripts under /sessions."
   echo "This command runs only in a Cowork or Claude Desktop session where the"
   echo "voice-forge plugin is mounted. Aborting."

--- a/plugins/voice-forge/commands/analyze-writing-voice.md
+++ b/plugins/voice-forge/commands/analyze-writing-voice.md
@@ -1,50 +1,154 @@
 ---
 name: analyze-writing-voice
 description: Analyze a sent-mail export to produce a data-driven written voice profile. Guides export, auto-discovers formats, parses, computes stats, verifies quotes, and writes a findings doc.
-argument-hint: "[--work-dir /path/to/output]"
 disable-model-invocation: true
 ---
 
 Analyze the user's sent-mail archive to produce a data-driven written voice profile.
 
+> **This command runs only in a Cowork or Claude Desktop session.** It relies on
+> the mounted plugin directory and an attached folder under `/sessions`. It will
+> not work in a plain terminal session — there is no `/sessions` mount to scan.
+
 Read `references/lessons-learned.md` before starting. Every guardrail in that file applies to this workflow.
 
 ---
 
-## Phase 0 — Export setup
+## Phase 0 — Setup (opening message → pre-parse scan → single confirmation)
 
-Ask the user for the following (use `AskUserQuestion` if available, otherwise ask in sequence):
+### Step 0a — Resolve plugin paths (fast-fail)
 
-1. **Archive directory** — instruct the user:
-   > "Create a folder on your machine and drop all your mail archive files into it — one or more exports from any combination of Apple Mail, Outlook for Mac, or Thunderbird. Then tell me the path to that folder. If you haven't exported yet, I can walk you through it — just tell me which mail client(s) you use."
-   
-   If the user needs export guidance, reference `references/export-guide.md` for step-by-step instructions per client. Do not proceed until the user confirms they have exported and provided a path.
+Resolve the scripts and references directories from the mounted plugin under
+`/sessions`. Both lookups must succeed before anything else runs:
 
-2. **Your email addresses** — ask for all addresses the user sends from (e.g. work + personal), space- or comma-separated. These are used to confirm authorship and filter out mail the user received but didn't write.
+```bash
+SCRIPTS_DIR="$(find /sessions -path "*/voice-forge/scripts" -type d 2>/dev/null | head -1)"
+PLUGIN_REFS_DIR="$(find /sessions -path "*/voice-forge/references" -type d 2>/dev/null | head -1)"
 
-3. **Working directory** — where to save analysis outputs. Default: `~/voice-forge-work/YYYY-MM-DD/` (use today's date). The user can override.
+if [ -z "$SCRIPTS_DIR" ] || [ ! -f "$SCRIPTS_DIR/parse_mbox.py" ]; then
+  echo "ERROR: could not locate voice-forge scripts under /sessions."
+  echo "This command runs only in a Cowork or Claude Desktop session where the"
+  echo "voice-forge plugin is mounted. Aborting."
+  exit 1
+fi
+if [ -z "$PLUGIN_REFS_DIR" ] || [ ! -f "$PLUGIN_REFS_DIR/lessons-learned.md" ]; then
+  echo "ERROR: could not locate voice-forge references under /sessions. Aborting."
+  exit 1
+fi
+echo "SCRIPTS_DIR=$SCRIPTS_DIR"
+echo "PLUGIN_REFS_DIR=$PLUGIN_REFS_DIR"
+```
 
-After collecting:
-- Run `ls -la "$ARCHIVE_DIR"` to confirm the directory exists and contains files.
-- If the directory is empty, does not exist, or contains no recognizable archive formats (`.mbox`, `.olm`, `.pst`), stop and guide the user before continuing.
-- Create the working directory: `mkdir -p "$WORK_DIR"`
-- Resolve the scripts directory:
-  ```bash
-  SCRIPTS_DIR="$(find . -path "*/voice-forge/scripts" -type d 2>/dev/null | head -1)"
-  ```
-  If the result is empty, try an absolute search from the home directory. Confirm `$SCRIPTS_DIR/parse_mbox.py` exists before continuing.
+If either guard fires, stop and tell the user this command must run inside a
+Cowork or Claude Desktop session. Do not fall back to scanning the whole
+filesystem.
+
+### Step 0b — Opening message
+
+Show the user this message before scanning (do not ask a questionnaire):
+
+> "I'll analyze your sent mail to build a data-driven voice profile. Attach a
+> folder containing your sent-mail exports to this session — one or more files
+> from any combination of Apple Mail (`.mbox` bundle), Outlook for Mac (`.olm`),
+> or Thunderbird (`.mbox`).
+>
+> If you haven't exported yet, tell me which mail client you use and I'll walk
+> you through it. Only export **sent** mail — received mail is not your voice."
+
+If the user needs export guidance, reference `references/export-guide.md` for
+step-by-step instructions per client.
+
+### Step 0c — Pre-parse scan
+
+Scan the attached session folder(s) under `/sessions` for recognizable archive
+files and derive the inputs automatically — do not prompt for the path:
+
+```bash
+ATTACHED_DIR="$(find /sessions -maxdepth 4 -type d \
+  \( -iname '*.mbox' -o -name '*' \) 2>/dev/null \
+  | xargs -I{} sh -c 'ls "{}"/*.olm "{}"/*.mbox 2>/dev/null | head -1 >/dev/null 2>&1 && echo "{}"' \
+  | head -1)"
+
+# Fallback: locate the directory that directly contains any archive file.
+if [ -z "$ATTACHED_DIR" ]; then
+  ATTACHED_DIR="$(find /sessions -type f \( -iname '*.olm' -o -iname '*.mbox' \) 2>/dev/null \
+    | head -1 | xargs -r dirname)"
+fi
+# Apple Mail bundles are directories named *.mbox — also detect those.
+if [ -z "$ATTACHED_DIR" ]; then
+  ATTACHED_DIR="$(find /sessions -type d -iname '*.mbox' 2>/dev/null \
+    | head -1 | xargs -r dirname)"
+fi
+
+if [ -z "$ATTACHED_DIR" ]; then
+  echo "No mail archive (.mbox / .olm) found in the attached session folder."
+  exit 1
+fi
+echo "ATTACHED_DIR=$ATTACHED_DIR"
+ls -la "$ATTACHED_DIR"
+```
+
+If no archive is found, stop and ask the user to attach a folder containing
+their exports (point them at `references/export-guide.md` if they haven't
+exported yet). Do not proceed.
+
+Derive the candidate owner email addresses by sampling the senders of the
+discovered archives. Run the parser's discovery over a small sample and tally
+the most frequent `From:` addresses, then propose them as `OWNER_EMAILS`:
+
+```bash
+OWNER_EMAILS="$(find "$ATTACHED_DIR" -type f \( -iname '*.mbox' -o -path '*.mbox/mbox' \) 2>/dev/null \
+  | head -3 \
+  | xargs -r grep -hoE '^From: .*<([^>]+)>|^From: ([^ ]+@[^ ]+)' 2>/dev/null \
+  | grep -oE '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' \
+  | sort | uniq -c | sort -rn | head -3 | awk '{print $2}' | paste -sd ',' -)"
+echo "Detected sender addresses: ${OWNER_EMAILS:-<none — ask the user>}"
+```
+
+If the sample is split (e.g. a 50/50 mix across work and personal domains) or no
+addresses are detected (e.g. OLM-only, where `From:` headers aren't in the file),
+include the detected addresses in the confirmation below and ask the user to
+confirm or supply the complete set.
+
+### Step 0d — Set work directory
+
+Anchor all outputs to the attached exports folder so the user finds them next to
+their archive:
+
+```bash
+WORK_DIR="$ATTACHED_DIR/voice-forge-work"
+mkdir -p "$WORK_DIR"
+echo "WORK_DIR=$WORK_DIR"
+```
+
+### Step 0e — Single confirmation gate
+
+Present a single confirmation summarizing what was detected, then proceed once
+the user confirms (this is the only gate in Phase 0):
+
+> "Here's what I found:
+> - **Exports folder:** `$ATTACHED_DIR` (`<N>` archive file(s))
+> - **Your addresses:** `$OWNER_EMAILS`
+> - **Outputs will be saved to:** `$WORK_DIR`
+>
+> Shall I proceed? If the addresses are wrong or incomplete, give me the full
+> list and I'll use that instead."
+
+Only continue after the user confirms. If the user corrects `OWNER_EMAILS`, use
+their list.
 
 ---
 
 ## Phase 1 — Parse
 
 Launch the `voice-parser` agent with:
-- `ARCHIVE_DIR` — the archive drop directory
-- `OWNER_EMAILS` — comma-separated list of the user's addresses
-- `WORK_DIR` — the working directory
+- `ARCHIVE_DIR` = `$ATTACHED_DIR` — the attached exports folder
+- `OWNER_EMAILS` — comma-separated list of the user's addresses (confirmed above)
+- `WORK_DIR` — `$ATTACHED_DIR/voice-forge-work`
 - `SCRIPTS_DIR` — the resolved scripts directory path
+- `PLUGIN_REFS_DIR` — the resolved references directory path
 
-**After the agent returns**, read `$WORK_DIR/voice-parser-output.json`. If the file is absent or `row_count` is 0: **STOP**. Tell the user that parsing produced no data, suggest re-checking the archive directory, and do not continue to Phase 2.
+**After the agent returns**, read `$WORK_DIR/voice-parser-output.json`. If the file is absent or `row_count` is 0: **STOP**. Tell the user that parsing produced no data, suggest re-checking the attached exports folder, and do not continue to Phase 2.
 
 ---
 
@@ -54,6 +158,7 @@ Launch the `voice-analyst` agent with:
 - `DATASET_PATH` = `$WORK_DIR/email_dataset.json`
 - `WORK_DIR`
 - `SCRIPTS_DIR`
+- `PLUGIN_REFS_DIR`
 
 ---
 
@@ -63,6 +168,7 @@ Launch the `voice-example-reader` agent with:
 - `DATASET_PATH` = `$WORK_DIR/email_dataset.json`
 - `WORK_DIR`
 - `SCRIPTS_DIR`
+- `PLUGIN_REFS_DIR`
 
 **After the agent returns**, read `$WORK_DIR/voice-example-reader-status.json`. If `verify_gate_passed` is false: **STOP**. Report how many quotes failed verification and why, and tell the user that no findings doc will be written until all quotes are verified.
 
@@ -70,11 +176,16 @@ Launch the `voice-example-reader` agent with:
 
 ## Phase 4 — Findings doc
 
-Ask the user where to save the findings doc. Default: `$WORK_DIR/voice-findings.md`.
+The findings doc is saved alongside the other outputs — do not prompt for a path:
+
+```bash
+SAVE_PATH="$WORK_DIR/voice-findings.md"
+```
 
 Launch the `voice-findings-writer` agent with:
 - `WORK_DIR`
-- `SAVE_PATH` — the confirmed save location
+- `SAVE_PATH` = `$WORK_DIR/voice-findings.md`
+- `PLUGIN_REFS_DIR`
 
 ---
 

--- a/plugins/voice-forge/references/lessons-learned.md
+++ b/plugins/voice-forge/references/lessons-learned.md
@@ -76,3 +76,16 @@ OLM files can be 10 GB or more. The bundled `parse_olm.py` already streams entri
 For mbox files: `mailbox.mbox()` is lazy and does not load the full file at once.
 
 If a user provides an unusually large archive (> 1 GB), remind them that parsing sent-only mail is the right scope. Parsing an entire inbox will be slow and produce off-voice signal from received mail.
+
+---
+
+## Rule 7 — Run only in a Cowork/Claude Desktop session; resolve plugin paths from `/sessions`
+
+`/analyze-writing-voice` depends on two things that only exist inside a Cowork or
+Claude Desktop session: the mounted plugin directory (so the bundled scripts and
+references are reachable) and an attached exports folder under `/sessions` (so
+there is mail to parse).
+
+- Resolve `SCRIPTS_DIR` and `PLUGIN_REFS_DIR` with `find /sessions -path "*/voice-forge/scripts"` (and `.../references`), not `find .`. The old `find .` lookup resolved against the agent's working directory, which is not the mounted plugin dir in the sandbox — it silently returned nothing.
+- **Fast-fail**: if either path is empty or its sentinel file (`parse_mbox.py`, `lessons-learned.md`) is missing, stop immediately with a clear message that the command requires a Cowork/Claude Desktop session. Do not fall back to scanning the whole filesystem.
+- Pass both `SCRIPTS_DIR` and `PLUGIN_REFS_DIR` explicitly to every agent. Inside agent Bash/Read calls, use `$SCRIPTS_DIR` / `$PLUGIN_REFS_DIR`. Instruction prose may still refer to `references/...` by name — that prose is injected from the mounted plugin dir at invocation time.

--- a/plugins/voice-forge/references/lessons-learned.md
+++ b/plugins/voice-forge/references/lessons-learned.md
@@ -86,6 +86,6 @@ Claude Desktop session: the mounted plugin directory (so the bundled scripts and
 references are reachable) and an attached exports folder under `/sessions` (so
 there is mail to parse).
 
-- Resolve `SCRIPTS_DIR` and `PLUGIN_REFS_DIR` with `find /sessions -path "*/voice-forge/scripts"` (and `.../references`), not `find .`. The old `find .` lookup resolved against the agent's working directory, which is not the mounted plugin dir in the sandbox — it silently returned nothing.
+- Resolve both paths by finding the plugin root once (`find /sessions -type d -name voice-forge | head -1`), then deriving `SCRIPTS_DIR="$ROOT/scripts"` and `PLUGIN_REFS_DIR="$ROOT/references"`. Do not use `find .` — that resolves against the agent's working directory, which is not the mounted plugin dir in the sandbox.
 - **Fast-fail**: if either path is empty or its sentinel file (`parse_mbox.py`, `lessons-learned.md`) is missing, stop immediately with a clear message that the command requires a Cowork/Claude Desktop session. Do not fall back to scanning the whole filesystem.
 - Pass both `SCRIPTS_DIR` and `PLUGIN_REFS_DIR` explicitly to every agent. Inside agent Bash/Read calls, use `$SCRIPTS_DIR` / `$PLUGIN_REFS_DIR`. Instruction prose may still refer to `references/...` by name — that prose is injected from the mounted plugin dir at invocation time.


### PR DESCRIPTION
## Summary

Overhauls the `voice-forge` `/analyze-writing-voice` workflow for reliable, Cowork-native execution. Fixes the broken script-path resolution that silently returned nothing in the sandbox, eliminates the runtime questionnaire in favor of a pre-parse scan plus a single confirmation, and anchors all outputs to the user's attached exports folder. Implements three issues on one branch because all three modify the same Phase 0 block of `analyze-writing-voice.md`.

## Changes

| File | Change |
|------|--------|
| `plugins/voice-forge/commands/analyze-writing-voice.md` | Rewrote Phase 0: resolve `SCRIPTS_DIR`/`PLUGIN_REFS_DIR` via `find /sessions` with fast-fail; removed `argument-hint` frontmatter and the AskUserQuestion questionnaire; added opening message, pre-parse scan deriving `ATTACHED_DIR`/`OWNER_EMAILS`, and a single confirmation gate; anchored `WORK_DIR="$ATTACHED_DIR/voice-forge-work"`; threaded `WORK_DIR`/`PLUGIN_REFS_DIR` to every phase; dropped the Phase 4 save-path prompt; hardcoded `SAVE_PATH` (#35, #33, #34) |
| `plugins/voice-forge/agents/voice-parser.md` | Accept `PLUGIN_REFS_DIR`; self-documenting comment on prose-vs-Bash path use (#35) |
| `plugins/voice-forge/agents/voice-analyst.md` | Accept `PLUGIN_REFS_DIR` (#35) |
| `plugins/voice-forge/agents/voice-example-reader.md` | Accept `PLUGIN_REFS_DIR` (#35) |
| `plugins/voice-forge/agents/voice-findings-writer.md` | Accept `PLUGIN_REFS_DIR`; read `findings-template.md` via `$PLUGIN_REFS_DIR` (#35) |
| `plugins/voice-forge/references/lessons-learned.md` | Added Rule 7 — Cowork/Claude Desktop-only execution; `/sessions` path resolution (#35) |
| `plugins/voice-forge/README.md` | Cowork-only execution requirement; updated Commands/Quick start/Privacy for the no-argument, attached-folder flow (#35, #33, #34) |
| `plugins/voice-forge/.claude-plugin/plugin.json` | Version 0.1.0 → 0.2.0 |
| `.claude-plugin/marketplace.json` | voice-forge version 0.1.0 → 0.2.0 (sync) |
| `README.md` | voice-forge catalog version 0.1.0 → 0.2.0 (sync) |

## Testing

- No CI / automated tests — pure-markdown plugin repository (per `CLAUDE.md`).
- Validated `marketplace.json` and `plugin.json` parse as JSON and the voice-forge version matches across both (0.2.0).
- Verified no residual `find . -path`, `argument-hint`, or `--work-dir` references remain in the plugin.
- Confirmed `PLUGIN_REFS_DIR` and `WORK_DIR` are threaded to Phases 1–4 so intermediate files (`email_dataset.json`, `voice-analyst-output.json`, `verified-quotes.json`) and `voice-findings.md` all land under `$ATTACHED_DIR/voice-forge-work/`.
- Manual Cowork-session end-to-end verification remains the recommended check (fast-fail in a non-Cowork terminal; OLM-only and split-address edge cases for the address-detection confirmation).

## Related Issues

Closes #35
Closes #33
Closes #34

---
*Automated by feature-implementer*
