### PR TITLE
feat: respect target repo branching conventions in feature-creator (v0.7.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "feature-creator",
       "source": "./plugins/feature-creator",
       "description": "Feature and bug-fix pipeline — plans, reviews, and implements GitHub issues labeled `feature - ready for claude` or `bug - ready for claude`.",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "author": {
         "name": "schmimran"
       }

--- a/plugins/feature-creator/.claude-plugin/plugin.json
+++ b/plugins/feature-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "feature-creator",
   "description": "Feature and bug-fix pipeline — plans, reviews, and implements GitHub issues labeled `feature - ready for claude` or `bug - ready for claude`.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "schmimran"
   }

--- a/plugins/feature-creator/README.md
+++ b/plugins/feature-creator/README.md
@@ -57,6 +57,18 @@ Automates feature development and bug remediation end-to-end. Point it at a GitH
 
 2. **Labels** must exist on the target repository (see step 2 in Quick Start above).
 
+3. **Branching convention**: The pipeline detects the integration branch (where
+   feature/fix branches are based) from the target repo's CLAUDE.md by looking
+   for the pattern `` rooted at `<branch>` `` in the Branching section. If no
+   match is found, it falls back to the repo's default branch. The release PR
+   always targets the repo's default branch. To override detection, pass
+   `--integration-branch <name>`:
+   ```
+   /feature-creator owner/repo --integration-branch develop
+   ```
+   The plugin requires a two-tier branching model (integration branch ≠ default
+   branch). If both resolve to the same branch, the pipeline halts with an error.
+
 ## Architecture
 
 | Component | Type | Model | Role |
@@ -121,7 +133,7 @@ The pipeline moves through six phases, 0 through 5.
 
 **Phase 4 — Implementation**: The implementer agent works through approved features one at a time. For each: it creates a branch, writes the code, runs tests (with up to 3 retry attempts), follows the merge checklist (`/simplify` + `/code-review`), and opens a PR.
 
-**Phase 5 — Merge and Cleanup**: Feature PRs are merged in implementation order. The release branch PR is created linking all features. By default, the pipeline pauses here for your confirmation before merging the release branch. Pass `--auto-merge` to skip the pause. After merge, it deletes all feature branches (local and remote), pulls main, and removes any worktree.
+**Phase 5 — Merge and Cleanup**: Feature PRs are merged in implementation order. The release branch PR is created linking all features. By default, the pipeline pauses here for your confirmation before merging the release branch. Pass `--auto-merge` to skip the pause. After merge, it deletes all feature branches (local and remote), pulls the default branch, and removes any worktree.
 
 ### Label Lifecycles
 
@@ -164,7 +176,7 @@ ready for claude  -->  triaged  -->  planned  -->  in progress  -->  complete
 
 ## Pausing Before Merge
 
-By default, the pipeline pauses after merging all feature PRs and creating the release branch PR. It prints the release PR link and asks for your confirmation before merging. This gives you a final review opportunity before the changes land on main.
+By default, the pipeline pauses after merging all feature PRs and creating the release branch PR. It prints the release PR link and asks for your confirmation before merging. This gives you a final review opportunity before the changes land on the default branch.
 
 To skip the pause and run the full pipeline end-to-end without stopping, pass `--auto-merge`:
 

--- a/plugins/feature-creator/README.md
+++ b/plugins/feature-creator/README.md
@@ -60,8 +60,9 @@ Automates feature development and bug remediation end-to-end. Point it at a GitH
 3. **Branching convention**: The pipeline detects the integration branch (where
    feature/fix branches are based) from the target repo's CLAUDE.md by looking
    for the pattern `` rooted at `<branch>` `` in the Branching section. If no
-   match is found, it falls back to the repo's default branch. The release PR
-   always targets the repo's default branch. To override detection, pass
+   match is found, the pipeline halts with an error and instructions to either
+   add the pattern or use `--integration-branch`. The release PR always targets
+   the repo's default branch. To override CLAUDE.md detection, pass
    `--integration-branch <name>`:
    ```
    /feature-creator owner/repo --integration-branch develop

--- a/plugins/feature-creator/agents/feature-implementer.md
+++ b/plugins/feature-creator/agents/feature-implementer.md
@@ -21,7 +21,11 @@ The branch prefix and conventional commit type vary by issue type:
 | Feature | `feature/` | `feat:` |
 | Bug | `fix/` | `fix:` |
 
-Both types branch from `stage` (single base; never stack).
+Both types branch from `<INTEGRATION_BRANCH>` (single base; never stack).
+
+Your prompt includes `Integration branch: <name>` — read that value and
+substitute it wherever you see `<INTEGRATION_BRANCH>` in these instructions
+and in the reference files you consult (merge-checklist, etc.).
 
 ## Prerequisites
 
@@ -84,23 +88,24 @@ gate in Step 2d.
 
 Process features **sequentially**, one at a time. For each feature:
 
-### 2a. Create Branch (flat-branch from stage — hard-coded)
+### 2a. Create Branch (flat-branch from `<INTEGRATION_BRANCH>`)
 
 **Never branch off another `feature/*` branch.** Every feature branch must be a
-flat branch rooted at `stage`. This is not a judgment call — it is a hard-coded
-first action. Stacking feature branches caused silent conflicts on prior runs.
+flat branch rooted at `<INTEGRATION_BRANCH>`. This is not a judgment call — it
+is a hard-coded first action. Stacking feature branches caused silent conflicts
+on prior runs.
 
-First, check out `stage` and pull:
+First, check out `<INTEGRATION_BRANCH>` and pull:
 ```
-git checkout stage && git pull origin stage
+git checkout <INTEGRATION_BRANCH> && git pull origin <INTEGRATION_BRANCH>
 ```
 
-Then verify the current branch is exactly `stage` before creating the feature
-branch. If it is not, abort this feature immediately:
+Then verify the current branch is exactly `<INTEGRATION_BRANCH>` before
+creating the feature branch. If it is not, abort this feature immediately:
 ```
 CURRENT=$(git branch --show-current)
-if [ "$CURRENT" != "stage" ]; then
-  echo "ERROR: expected stage, got $CURRENT — aborting feature #<NUMBER>"
+if [ "$CURRENT" != "<INTEGRATION_BRANCH>" ]; then
+  echo "ERROR: expected <INTEGRATION_BRANCH>, got $CURRENT — aborting feature #<NUMBER>"
   # go to Error Recovery, label the issue "feature - human review"
   exit 1
 fi
@@ -182,7 +187,7 @@ Extract the "Affected Files" list from the plan (saved in `/tmp/plan-<N>.md`)
 and for every file whose action is `Create` or `Modify`, run:
 
 ```
-git diff origin/stage -- <planned-file>
+git diff origin/<INTEGRATION_BRANCH> -- <planned-file>
 ```
 
 For every planned `Create`/`Modify` file, confirm the diff is **non-empty**. If
@@ -190,7 +195,7 @@ any planned file shows an empty diff, conflict resolution silently dropped the
 feature's changes. Do not push. Go to **Error Recovery** with an error message
 identifying which planned file lost its changes.
 
-Deleted files should be verified with `git log origin/stage..HEAD -- <file>`
+Deleted files should be verified with `git log origin/<INTEGRATION_BRANCH>..HEAD -- <file>`
 showing a deletion commit.
 
 ### 2e. Follow Merge Checklist
@@ -224,19 +229,19 @@ gh issue edit <NUMBER> --repo <OWNER/REPO> \
   --remove-label "bug - in progress" --add-label "bug - complete"
 ```
 
-### 2g. Return to stage
+### 2g. Return to `<INTEGRATION_BRANCH>`
 
 ```
-git checkout stage
+git checkout <INTEGRATION_BRANCH>
 ```
 
 ## Step 3: Create Release Branch
 
 After all features are implemented, create and push the release branch from
-`stage`:
+`<INTEGRATION_BRANCH>`:
 
 ```
-git checkout stage && git pull origin stage
+git checkout <INTEGRATION_BRANCH> && git pull origin <INTEGRATION_BRANCH>
 git checkout -b release/<YYYY-MM-DD>
 git push origin release/<YYYY-MM-DD>
 ```
@@ -277,7 +282,7 @@ fails:
 
 3. Clean up the local branch (use the prefix that was created in 2a):
    ```
-   git checkout stage
+   git checkout <INTEGRATION_BRANCH>
    git branch -D feature/<NUMBER>-<SLUG>   # or fix/<NUMBER>-<SLUG> for bugs
    ```
 

--- a/plugins/feature-creator/commands/feature-creator.md
+++ b/plugins/feature-creator/commands/feature-creator.md
@@ -1,7 +1,7 @@
 ---
 name: feature-creator
 description: End-to-end pipeline — plans, reviews, and implements GitHub issues labeled `feature - ready for claude` or `bug - ready for claude`
-argument-hint: "[repo-owner/repo-name] [--auto-merge]"
+argument-hint: "[repo-owner/repo-name] [--auto-merge] [--integration-branch <name>]"
 disable-model-invocation: true
 ---
 
@@ -104,6 +104,12 @@ after the plan is posted.
      echo "ERROR: Could not detect an integration branch from CLAUDE.md (looked for 'rooted at \`<branch>\`')."
      echo "       Add the pattern to your CLAUDE.md Branching section (e.g. 'One branch per change rooted at \`stage\`')"
      echo "       or pass --integration-branch <name> to specify the branch explicitly."
+     exit 1
+   fi
+
+   # Guard: branch name must contain only safe characters
+   if ! echo "$INTEGRATION_BRANCH" | grep -qE '^[a-zA-Z0-9._/-]+$'; then
+     echo "ERROR: detected integration branch '${INTEGRATION_BRANCH}' contains unsafe characters — halting"
      exit 1
    fi
 

--- a/plugins/feature-creator/commands/feature-creator.md
+++ b/plugins/feature-creator/commands/feature-creator.md
@@ -60,6 +60,11 @@ after the plan is posted.
    - If neither works, stop and ask the user for the repository.
    - Note whether `--auto-merge` was passed — this controls Phase 5 behavior.
    - Note the value of `--integration-branch` if provided — it overrides CLAUDE.md detection in step 4.
+   - Capture the repo's default branch now (reused in step 4 as `RELEASE_TARGET`):
+     ```
+     DEFAULT_BRANCH=$(gh repo view <OWNER/REPO> --json defaultBranchRef -q .defaultBranchRef.name)
+     ```
+     Record `DEFAULT_BRANCH` as a pipeline-scoped variable.
 
 3. Verify required labels exist on the repo:
    ```
@@ -79,10 +84,11 @@ after the plan is posted.
 
 4. Detect the branching configuration for the target repository. Record
    `INTEGRATION_BRANCH` and `RELEASE_TARGET` as pipeline-scoped variables —
-   pass them to all downstream phases that need them.
+   pass them to all downstream phases that need them. `RELEASE_TARGET` is
+   always `DEFAULT_BRANCH` (captured in step 2).
 
-   If `--integration-branch <name>` was provided in `$ARGUMENTS`, use that
-   value as `INTEGRATION_BRANCH` and skip the CLAUDE.md parse. Otherwise:
+   If `--integration-branch <name>` was provided, use that value directly.
+   Otherwise parse from CLAUDE.md:
 
    ```bash
    # Fetch target repo's CLAUDE.md (silently skip if absent)
@@ -93,12 +99,14 @@ after the plan is posted.
    INTEGRATION_BRANCH=$(printf '%s' "$CLAUDE_MD" \
      | sed -nE 's/.*rooted at `([^`]+)`.*/\1/p' | head -1)
 
-   # Default branch (used for fallback and release target)
-   DEFAULT_BRANCH=$(gh repo view <OWNER/REPO> --json defaultBranchRef -q .defaultBranchRef.name)
-
+   # Error if no pattern found and no --integration-branch override was given
    if [ -z "$INTEGRATION_BRANCH" ]; then
-     INTEGRATION_BRANCH="$DEFAULT_BRANCH"
+     echo "ERROR: Could not detect an integration branch from CLAUDE.md (looked for 'rooted at \`<branch>\`')."
+     echo "       Add the pattern to your CLAUDE.md Branching section (e.g. 'One branch per change rooted at \`stage\`')"
+     echo "       or pass --integration-branch <name> to specify the branch explicitly."
+     exit 1
    fi
+
    RELEASE_TARGET="$DEFAULT_BRANCH"
 
    echo "Integration branch: ${INTEGRATION_BRANCH}"
@@ -110,9 +118,9 @@ after the plan is posted.
      exit 1
    fi
 
-   # Guard: two-tier branching model required
+   # Guard: integration branch must differ from the default branch
    if [ "$INTEGRATION_BRANCH" = "$RELEASE_TARGET" ]; then
-     echo "ERROR: INTEGRATION_BRANCH and RELEASE_TARGET are both '${INTEGRATION_BRANCH}' — feature-creator requires a two-tier branching model (integration branch ≠ default branch). Use --integration-branch <name> to specify a non-default integration branch."
+     echo "ERROR: integration branch '${INTEGRATION_BRANCH}' is the same as the default branch '${RELEASE_TARGET}'. feature-creator requires a two-tier model (integration branch ≠ default branch)."
      exit 1
    fi
    ```
@@ -315,7 +323,9 @@ rely on GitHub's closing keywords.
 
 Construct the release PR body using the template in
 `references/release-pr-template.md` (read that file for the exact format).
-Populate it from the Phase 4 output:
+Substitute `<INTEGRATION_BRANCH>` in the template body with the detected
+`INTEGRATION_BRANCH` value before writing to `/tmp/release-pr-body.md`.
+Populate from the Phase 4 output:
 
 - The **Summary** section lists one line per successfully-merged PR,
   including PR number, type marker (`feat` or `fix`), title, and issue

--- a/plugins/feature-creator/commands/feature-creator.md
+++ b/plugins/feature-creator/commands/feature-creator.md
@@ -55,10 +55,11 @@ after the plan is posted.
    If not authenticated, stop and tell the user to run `gh auth login`.
 
 2. Resolve the target repository and flags:
-   - Parse `$ARGUMENTS`: extract `OWNER/REPO` and check for the `--auto-merge` flag.
+   - Parse `$ARGUMENTS`: extract `OWNER/REPO`, check for the `--auto-merge` flag, and check for `--integration-branch <name>`.
    - If no `OWNER/REPO` is given, detect from the current directory: `gh repo view --json nameWithOwner -q .nameWithOwner`
    - If neither works, stop and ask the user for the repository.
    - Note whether `--auto-merge` was passed — this controls Phase 5 behavior.
+   - Note the value of `--integration-branch` if provided — it overrides CLAUDE.md detection in step 4.
 
 3. Verify required labels exist on the repo:
    ```
@@ -75,6 +76,46 @@ after the plan is posted.
 
    If any are missing, print the `gh label create` commands from the plugin
    README and stop.
+
+4. Detect the branching configuration for the target repository. Record
+   `INTEGRATION_BRANCH` and `RELEASE_TARGET` as pipeline-scoped variables —
+   pass them to all downstream phases that need them.
+
+   If `--integration-branch <name>` was provided in `$ARGUMENTS`, use that
+   value as `INTEGRATION_BRANCH` and skip the CLAUDE.md parse. Otherwise:
+
+   ```bash
+   # Fetch target repo's CLAUDE.md (silently skip if absent)
+   CLAUDE_MD=$(gh api repos/<OWNER/REPO>/contents/CLAUDE.md --jq '.content' 2>/dev/null \
+     | tr -d '\n' | base64 --decode 2>/dev/null || echo "")
+
+   # Extract integration branch from "rooted at `<branch>`" pattern (BSD/GNU-safe)
+   INTEGRATION_BRANCH=$(printf '%s' "$CLAUDE_MD" \
+     | sed -nE 's/.*rooted at `([^`]+)`.*/\1/p' | head -1)
+
+   # Default branch (used for fallback and release target)
+   DEFAULT_BRANCH=$(gh repo view <OWNER/REPO> --json defaultBranchRef -q .defaultBranchRef.name)
+
+   if [ -z "$INTEGRATION_BRANCH" ]; then
+     INTEGRATION_BRANCH="$DEFAULT_BRANCH"
+   fi
+   RELEASE_TARGET="$DEFAULT_BRANCH"
+
+   echo "Integration branch: ${INTEGRATION_BRANCH}"
+   echo "Release target: ${RELEASE_TARGET}"
+
+   # Guard: verify integration branch exists on remote
+   if ! git ls-remote --heads origin "$INTEGRATION_BRANCH" | grep -q "$INTEGRATION_BRANCH"; then
+     echo "ERROR: integration branch '${INTEGRATION_BRANCH}' not found on remote — halting"
+     exit 1
+   fi
+
+   # Guard: two-tier branching model required
+   if [ "$INTEGRATION_BRANCH" = "$RELEASE_TARGET" ]; then
+     echo "ERROR: INTEGRATION_BRANCH and RELEASE_TARGET are both '${INTEGRATION_BRANCH}' — feature-creator requires a two-tier branching model (integration branch ≠ default branch). Use --integration-branch <name> to specify a non-default integration branch."
+     exit 1
+   fi
+   ```
 
 ## Phase 0: Triage
 
@@ -229,6 +270,7 @@ Wait for the agent to complete. Check its output:
 Use the Agent tool to launch the feature-implementer agent with the following prompt:
 
 > You are the feature-implementer. Target repository: <OWNER/REPO>
+> Integration branch: <INTEGRATION_BRANCH>
 
 Wait for the agent to complete. Collect its output:
 - Record each PR number alongside its issue type (feature or bug) and the
@@ -264,7 +306,7 @@ to the **type-appropriate** human-review label, and continue with the next PR:
 
 ### 5c. Create and merge the release branch PR
 
-The release PR merges `stage` into `main` (the default branch). GitHub only
+The release PR merges `<INTEGRATION_BRANCH>` into `<RELEASE_TARGET>` (the default branch). GitHub only
 auto-closes issues when a PR merges into the default branch, so this is the
 only opportunity in the pipeline to auto-close issues — every feature **or
 bug** issue successfully merged in Phase 5b must appear as a `Closes #<N>`
@@ -291,7 +333,7 @@ in the Closes section — those issues remain open for manual follow-up.
 issue numbers for every PR merged successfully in Phase 5b — across both
 types. For each issue number, confirm the composed body contains a matching
 `Closes #<N>` line. If any merged issue is missing, fail with an error and
-stop — do not create the PR. This guarantees the release merge into `main`
+stop — do not create the PR. This guarantees the release merge into `<RELEASE_TARGET>`
 will auto-close every feature **and bug** issue landed in this release.
 
 Write the body to `/tmp/release-pr-body.md` and create the PR with
@@ -310,7 +352,7 @@ for N in <merged_issue_numbers>; do
   fi
 done
 
-gh pr create --repo <OWNER/REPO> --base main --head release/<YYYY-MM-DD> \
+gh pr create --repo <OWNER/REPO> --base <RELEASE_TARGET> --head release/<YYYY-MM-DD> \
   --title "Release <YYYY-MM-DD>" --body-file /tmp/release-pr-body.md
 ```
 
@@ -335,7 +377,7 @@ prefix is `feature/` for feature issues and `fix/` for bug issues — clean up
 both:
 
 ```
-git checkout main && git pull
+git checkout <RELEASE_TARGET> && git pull
 
 # Delete remote branches (always run — --delete-branch in 5b handles
 # GitHub's remote ref but local tracking refs require explicit cleanup)

--- a/plugins/feature-creator/references/merge-checklist.md
+++ b/plugins/feature-creator/references/merge-checklist.md
@@ -57,7 +57,7 @@ For every file listed as `Create` or `Modify` in the plan's "Affected Files"
 table, run:
 
 ```
-git diff origin/stage -- <planned-file>
+git diff origin/<INTEGRATION_BRANCH> -- <planned-file>
 ```
 
 Every planned `Create`/`Modify` file must show a non-empty diff. If any planned
@@ -83,8 +83,13 @@ injection and cross-feature collisions:
 cat > /tmp/pr-body-<N>.md << 'PR_EOF'
 <BODY>
 PR_EOF
-gh pr create --repo <OWNER/REPO> --title "<TITLE>" --body-file /tmp/pr-body-<N>.md --base stage
+gh pr create --repo <OWNER/REPO> --title "<TITLE>" --body-file /tmp/pr-body-<N>.md --base <INTEGRATION_BRANCH>
 ```
+
+`<INTEGRATION_BRANCH>` is the integration branch detected by the orchestrator
+and passed to the implementer via `Integration branch: <name>` in the prompt —
+substitute the actual branch name (e.g. `stage`, `develop`) wherever this
+placeholder appears.
 
 ## 6. Code Review
 

--- a/plugins/feature-creator/references/merge-checklist.md
+++ b/plugins/feature-creator/references/merge-checklist.md
@@ -91,11 +91,6 @@ PR_EOF
 gh pr create --repo <OWNER/REPO> --title "<TITLE>" --body-file /tmp/pr-body-<N>.md --base <INTEGRATION_BRANCH>
 ```
 
-`<INTEGRATION_BRANCH>` is the integration branch detected by the orchestrator
-and passed to the implementer via `Integration branch: <name>` in the prompt —
-substitute the actual branch name (e.g. `stage`, `develop`) wherever this
-placeholder appears.
-
 ## 6. Code Review
 
 Run `/code-review` (a built-in Claude Code skill) on the PR. This checks for:

--- a/plugins/feature-creator/references/merge-checklist.md
+++ b/plugins/feature-creator/references/merge-checklist.md
@@ -1,5 +1,10 @@
 # Merge Checklist
 
+> **`<INTEGRATION_BRANCH>` placeholder**: wherever this file shows
+> `<INTEGRATION_BRANCH>`, substitute the actual integration branch name
+> (e.g. `stage`, `develop`) from the `Integration branch:` value in your
+> prompt before executing any command.
+
 Follow these steps in order after implementation and verification pass.
 
 ## 1. Simplify

--- a/plugins/feature-creator/references/pr-template.md
+++ b/plugins/feature-creator/references/pr-template.md
@@ -35,6 +35,12 @@ and future archaeologists can understand the fix without opening the issue.>
 ## Related Issue
 
 Closes #<ISSUE_NUMBER>
+<!--
+Note: GitHub only auto-closes issues on merges to the default branch.
+Individual feature/bug PRs target the integration branch, so this Closes
+line is informational here — the release PR is responsible for actual issue
+closure when it merges into the default branch.
+-->
 
 ---
 *Automated by feature-implementer*

--- a/plugins/feature-creator/references/release-pr-template.md
+++ b/plugins/feature-creator/references/release-pr-template.md
@@ -5,12 +5,12 @@ Use this template to construct the release PR body. The orchestrator
 Phase 4 implementation output.
 
 The **`Closes` section is required**. GitHub only auto-closes issues when a PR
-merges into the repository's default branch (`main`). Feature and bug-fix PRs
-merge into `stage`, so per-issue auto-close does not fire there. The release
-PR is the only merge into `main`, so every feature **and bug** issue that
-landed in this release must appear as a `Closes #<N>` line in this body —
-otherwise the issues will remain open after the release merges and require
-manual cleanup.
+merges into the repository's default branch. Feature and bug-fix PRs
+merge into `<INTEGRATION_BRANCH>`, so per-issue auto-close does not fire there.
+The release PR is the only merge into the default branch, so every feature
+**and bug** issue that landed in this release must appear as a `Closes #<N>`
+line in this body — otherwise the issues will remain open after the release
+merges and require manual cleanup.
 
 Before calling `gh pr create`, the orchestrator must confirm that every
 successfully-merged issue from Phase 4 (across both types) appears in the
@@ -24,7 +24,7 @@ creation.
 
 ## Summary
 
-This release bundles the following PRs merged into `stage`:
+This release bundles the following PRs merged into `<INTEGRATION_BRANCH>`:
 
 ### Features
 

--- a/plugins/feature-creator/references/release-pr-template.md
+++ b/plugins/feature-creator/references/release-pr-template.md
@@ -17,6 +17,10 @@ successfully-merged issue from Phase 4 (across both types) appears in the
 `Closes` section. Missing entries must fail the pre-flight check and block PR
 creation.
 
+The orchestrator substitutes `<INTEGRATION_BRANCH>` in the template body below
+with the detected integration branch value before writing to
+`/tmp/release-pr-body.md`.
+
 ---
 
 ```markdown


### PR DESCRIPTION
## Summary

- Adds dynamic `INTEGRATION_BRANCH` detection from the target repo's CLAUDE.md (`rooted at \`<branch>\`` pattern) so the pipeline no longer hard-codes `stage` throughout
- Adds `--integration-branch <name>` CLI flag as an explicit override
- `RELEASE_TARGET` is always the repo's default branch (detected via `gh repo view`)
- Adds guards: character-safety check on the detected branch name, remote-existence check, and a two-tier model check (integration branch ≠ default branch)

## Test plan

- [ ] Run `/feature-creator schmimran/claude-skills` — Prerequisites step should log `Integration branch: stage` and `Release target: main` (detected from "rooted at \`stage\`" in this repo's CLAUDE.md)
- [ ] Verify feature branch is created from `stage`, individual PR targets `stage`, and release PR targets `main`
- [ ] Test `--integration-branch develop` override on a repo with `develop` branch
- [ ] Test that a repo with no matching CLAUDE.md pattern and no flag gives a clear error with guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
